### PR TITLE
[DRAFT] Routing for lowest inference time

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           pip install -r requirements.txt
       - name: Delete previous model, if exists
         run: |
-          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_BASE_REF') or os.environ.get('GITHUB_REF_NAME'))")
+          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_REF_NAME') or 'main')")
           python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
           name='test-bloomd-350m-$HF_TAG', organization='bloom-testing')" || true
       - name: Convert model and push to hub
@@ -64,7 +64,7 @@ jobs:
           pip install -r requirements-dev.txt
       - name: Test
         run: |
-          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_BASE_REF') or os.environ.get('GITHUB_REF_NAME'))")
+          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_REF_NAME') or 'main')")
           export MODEL_NAME=bloom-testing/test-bloomd-350m-$HF_TAG
           export REF_NAME=bigscience/bloom-350m
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,36 +6,36 @@ on:
   pull_request:
 
 jobs:
-  convert-model:
-    runs-on: ubuntu-latest
-    env:
-      BLOOM_TESTING_WRITE_TOKEN: ${{ secrets.BLOOM_TESTING_WRITE_TOKEN }}
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: Key-v1-py3.9-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Delete previous model, if exists
-        run: |
-          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
-          name='test-bloomd-350m-$HF_TAG', organization='bloom-testing')" || true
-      - name: Convert model and push to hub
-        run: |
-          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-          python -m cli.convert_model --model bigscience/bloom-350m  --output_path ./converted_model \
-            --output_repo bloom-testing/test-bloomd-350m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN
+#  convert-model:
+#    runs-on: ubuntu-latest
+#    env:
+#      BLOOM_TESTING_WRITE_TOKEN: ${{ secrets.BLOOM_TESTING_WRITE_TOKEN }}
+#    timeout-minutes: 15
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Set up Python
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.9
+#      - name: Cache dependencies
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/.cache/pip
+#          key: Key-v1-py3.9-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install -r requirements.txt
+#      - name: Delete previous model, if exists
+#        run: |
+#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+#          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
+#          name='test-bloomd-350m-$HF_TAG', organization='bloom-testing')" || true
+#      - name: Convert model and push to hub
+#        run: |
+#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+#          python -m cli.convert_model --model bigscience/bloom-350m  --output_path ./converted_model \
+#            --output_repo bloom-testing/test-bloomd-350m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN
 
 
   run-tests:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -40,7 +40,7 @@ jobs:
 
   run-tests:
     runs-on: ubuntu-latest
-    needs: convert-model
+    #needs: convert-model
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9 ]

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -2,4 +2,4 @@ from src.client.inference_session import RemoteSequentialInferenceSession, Remot
 from src.client.remote_block import RemoteTransformerBlock
 from src.client.remote_model import DistributedBloomConfig, DistributedBloomForCausalLM, DistributedBloomModel
 from src.client.remote_sequential import RemoteSequential
-from src.client.sequence_manager import RemoteSequenceManager
+from src.client.routing import RemoteSequenceManager

--- a/src/client/inference_session.py
+++ b/src/client/inference_session.py
@@ -18,7 +18,7 @@ from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
 from hivemind.p2p import StubBase
 from hivemind.proto import runtime_pb2
 
-from src.client.sequence_manager import RemoteSequenceManager
+from src.client.routing import RemoteSequenceManager
 from src.data_structures import CHAIN_DELIMITER, ModuleUID, RemoteSpanInfo, RPCInfo
 from src.server.handler import TransformerConnectionHandler
 

--- a/src/client/remote_sequential.py
+++ b/src/client/remote_sequential.py
@@ -43,7 +43,7 @@ class RemoteSequential(nn.Module):
         block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(num_blocks)]
         if sequence_manager is None:
             logger.debug(f"Creating new sequence manager for block uids: {block_uids}")
-            self.sequence_manager = RemoteSequenceManager(dht, block_uids, self.p2p)
+            self.sequence_manager = RemoteSequenceManager(dht, block_uids, p2p=self.p2p, start=True)
             self.is_subsequence = False
         else:
             logger.debug(f"Reusing sequence manager with {len(sequence_manager)} modules")

--- a/src/client/remote_sequential.py
+++ b/src/client/remote_sequential.py
@@ -40,7 +40,7 @@ class RemoteSequential(nn.Module):
         self.p2p = RemoteExpertWorker.run_coroutine(dht.replicate_p2p()) if p2p is None else p2p
 
         num_blocks = self.config.n_layer if sequence_manager is None else len(sequence_manager)
-        block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(num_blocks)]
+        block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(num_blocks))
         if sequence_manager is None:
             logger.debug(f"Creating new sequence manager for block uids: {block_uids}")
             self.sequence_manager = RemoteSequenceManager(dht, block_uids, p2p=self.p2p, start=True)
@@ -48,7 +48,7 @@ class RemoteSequential(nn.Module):
         else:
             logger.debug(f"Reusing sequence manager with {len(sequence_manager)} modules")
             self.sequence_manager = sequence_manager
-            assert isinstance(sequence_manager.block_uids, list)
+            assert isinstance(sequence_manager.block_uids, tuple)
             self.is_subsequence = self.sequence_manager.block_uids != block_uids
 
     def forward(self, inputs: torch.Tensor):

--- a/src/client/remote_sequential.py
+++ b/src/client/remote_sequential.py
@@ -11,7 +11,7 @@ from torch import nn
 import src
 from src.client.inference_session import RemoteSequentialInferenceSession
 from src.client.remote_block import RemoteTransformerBlock
-from src.client.sequence_manager import RemoteSequenceManager
+from src.client.routing.sequence_manager import RemoteSequenceManager
 from src.data_structures import UID_DELIMITER
 from src.dht_utils import _create_remote_modules_from_infos
 

--- a/src/client/routing/__init__.py
+++ b/src/client/routing/__init__.py
@@ -1,0 +1,3 @@
+from src.client.routing.routing_strategy import *
+from src.client.routing.sequence_info import RemoteSequenceInfo
+from src.client.routing.sequence_manager import RemoteSequenceManager

--- a/src/client/routing/routing_strategy.py
+++ b/src/client/routing/routing_strategy.py
@@ -1,0 +1,82 @@
+"""RoutingStrategies are helpers for RemoteSequenceManager (sequence_manager.py) that implement make_sequence"""
+import random
+from abc import ABC
+from typing import List, Optional, Tuple
+
+from src.client.routing.sequence_info import RemoteSequenceInfo
+from src.data_structures import RemoteSpanInfo, ServerState
+
+
+class RoutingStrategyBase(ABC):
+    name: str  # used in RemoteSequenceManager.make_sequence(mode, **kwargs)
+
+    def update_(self):
+        """Called when sequence manager fetches new info from the dht"""
+        raise NotImplementedError()
+
+    def make_sequence(self, start_index: int = 0, end_index: Optional[int] = None, **kwargs):
+        """Form and return a sequence;"""
+        raise NotImplementedError()
+
+
+class RandomRoutingStrategy(RoutingStrategyBase):
+    """choose a random compatible server at each branch and include all layers served by it"""
+
+    name = "RANDOM"
+
+    def __init__(self, sequence_info: RemoteSequenceInfo):
+        self.sequence_info = sequence_info
+        self.spans_by_priority: List[RemoteSpanInfo] = []  # sorted from best to worst
+        self.spans_containing_block: Tuple[List[RemoteSpanInfo], ...] = tuple([] for _ in range(len(sequence_info)))
+
+    def update_(self):
+        for uid, info in zip(self.sequence_info.block_uids, self.sequence_info.block_infos):
+            assert info is not None, f"Found no remote peers for block {uid}"
+            # TODO change this to waiting and warning - instead of crashing the thread :)
+
+        closed_spans = []
+        active_spans = {}
+        for block_index, info in enumerate(self.sequence_info.block_infos):
+            for peer_id, server in info.servers.items():
+                if server.state != ServerState.ONLINE:
+                    continue
+                if peer_id not in active_spans:
+                    active_spans[peer_id] = RemoteSpanInfo(start=block_index, end=block_index + 1, peer_id=peer_id)
+                else:  # peer_id in active_spans
+                    active_spans[peer_id].end = block_index + 1
+
+            for peer_id in list(active_spans.keys()):
+                if (
+                    peer_id not in info.servers
+                    or info.servers[peer_id].state != ServerState.ONLINE
+                    or block_index == len(self.sequence_info.block_infos) - 1
+                ):
+                    closed_spans.append(active_spans.pop(peer_id))
+        assert not active_spans
+
+        closed_spans.sort(key=lambda span: span.end - span.start, reverse=True)
+        self.spans_by_priority = closed_spans
+
+        spans_containing_block = tuple(list() for _ in range(len(self.sequence_info.block_infos)))
+        for span in closed_spans:
+            for block_index in range(span.start, span.end):
+                spans_containing_block[block_index].append(span)
+
+        self.spans_containing_block = spans_containing_block
+        assert self.spans_by_priority and self.spans_containing_block
+
+    def make_sequence(self, start_index: int = 0, end_index: Optional[int] = None, **kwargs):
+        assert not kwargs, f"Unexpected kwargs: {kwargs}"
+        end_index = end_index if end_index is not None else len(self.sequence_info)
+        span_sequence = []
+        current_index = start_index
+        while current_index < end_index:
+            candidate_spans = self.spans_containing_block[current_index]
+            chosen_span = random.choice(candidate_spans)
+            assert chosen_span.start <= current_index < chosen_span.end
+            span_sequence.append(chosen_span)
+            current_index = chosen_span.end
+        return span_sequence
+
+
+ALL_ROUTING_STRATEGIES = (RandomRoutingStrategy,)

--- a/src/client/routing/routing_strategy.py
+++ b/src/client/routing/routing_strategy.py
@@ -8,8 +8,6 @@ from src.data_structures import RemoteSpanInfo, ServerState
 
 
 class RoutingStrategyBase(ABC):
-    name: str  # used in RemoteSequenceManager.make_sequence(mode, **kwargs)
-
     def update_(self):
         """Called when sequence manager fetches new info from the dht"""
         raise NotImplementedError()
@@ -21,8 +19,6 @@ class RoutingStrategyBase(ABC):
 
 class RandomRoutingStrategy(RoutingStrategyBase):
     """choose a random compatible server at each branch and include all layers served by it"""
-
-    name = "RANDOM"
 
     def __init__(self, sequence_info: RemoteSequenceInfo):
         self.sequence_info = sequence_info
@@ -79,4 +75,4 @@ class RandomRoutingStrategy(RoutingStrategyBase):
         return span_sequence
 
 
-ALL_ROUTING_STRATEGIES = (RandomRoutingStrategy,)
+ALL_ROUTING_STRATEGIES = dict(RANDOM=RandomRoutingStrategy)

--- a/src/client/routing/sequence_info.py
+++ b/src/client/routing/sequence_info.py
@@ -1,0 +1,61 @@
+import dataclasses
+from typing import Iterable, Tuple, Type, TypeVar
+
+from hivemind import DHT, get_logger, use_hivemind_log_handler
+
+from src.data_structures import ModuleUID, RemoteModuleInfo
+from src.dht_utils import get_remote_module_infos
+
+use_hivemind_log_handler("in_root_logger")
+logger = get_logger(__file__)
+
+
+T = TypeVar("T")
+
+
+@dataclasses.dataclass(frozen=True)
+class RemoteSequenceInfo:
+    """
+    A dataclass that stores general information about which servers hold any given layer;
+    - updated by RemoteSequenceManager in a background thread
+    - accessed by routing strategies in .on_update
+
+    :note: this class should *not* be modified by RoutingStrategy.on_update to avoid interference between strategies;
+     Any metadata specific to one routing strategy, it should be stored inside that strategy. Any information that
+     is used by most routing strategies should be moved from said strategies to this class.
+
+    """
+
+    block_uids: Tuple[ModuleUID, ...]
+    block_infos: Tuple[RemoteModuleInfo, ...]  # note: the contents of RemoteModuleInfo can and will be updated
+
+    @classmethod
+    def make_empty(cls: Type[T], block_uids: Iterable[ModuleUID]) -> T:
+        block_uids = tuple(block_uids)
+        empty_block_infos = tuple(RemoteModuleInfo(uid, dict()) for uid in block_uids)
+        return cls(block_uids, empty_block_infos)
+
+    def __getitem__(self, ix: slice):
+        assert isinstance(ix, slice)
+        return RemoteSequenceInfo(self.block_uids[ix], self.block_infos[ix])
+
+    def __len__(self):
+        return len(self.block_uids)
+
+    def update_(self, dht: DHT):
+        new_block_infos = get_remote_module_infos(dht, self.block_uids, expiration_time=float("inf"))
+        assert len(new_block_infos) == len(self.block_uids)
+        for block_index, (uid, info) in enumerate(zip(self.block_uids, new_block_infos)):
+            if info is None:
+                logger.warning(f"Found no block info for block {uid}")
+                continue
+            if not isinstance(info, RemoteModuleInfo):
+                logger.warning(f"Unexpected dht entry type for {uid}: {info}")
+                continue
+            if not info.servers:
+                logger.warning(f"Found no active peers for block {uid}")
+                continue
+            if info.uid != uid:
+                logger.warning(f"The DHT entry for {uid} actually points to {info.uid}")
+                continue
+            self.block_infos[block_index].servers = info.servers

--- a/src/client/routing/sequence_manager.py
+++ b/src/client/routing/sequence_manager.py
@@ -78,6 +78,7 @@ class RemoteSequenceManager(threading.Thread):
     def run(self) -> None:
         self.ready.set()
         threading.Event().wait()
+
         # TODO
 
     def make_sequence(

--- a/src/client/routing/sequence_manager.py
+++ b/src/client/routing/sequence_manager.py
@@ -77,10 +77,15 @@ class RemoteSequenceManager(threading.Thread):
 
     def run(self) -> None:
         self.ready.set()
+        threading.Event().wait()
         # TODO
 
     def make_sequence(
-        self, strategy: Union[str, RoutingStrategyBase], start_index: int = 0, end_index: Optional[int] = None, **kwargs
+        self,
+        strategy: Union[None, str, RoutingStrategyBase] = None,
+        start_index: int = 0,
+        end_index: Optional[int] = None,
+        **kwargs,
     ) -> Sequence[RemoteSpanInfo]:
         """
         Form a sequence of remote servers that collectively serve all consecutive layers
@@ -95,6 +100,8 @@ class RemoteSequenceManager(threading.Thread):
             logger.warning(f"{self.__class__.__name__} is still initializing, waiting until it's ready...")
             self.ready.wait()
             logger.warning(f"Finished waiting for {self.__class__.__name__} to initialize")
+        if strategy is None:
+            strategy = next(iter(self.routing_strategies))
         if not isinstance(strategy, RoutingStrategyBase):
             strategy = self.routing_strategies[strategy]
         return strategy.make_sequence(start_index, end_index, **kwargs)

--- a/src/client/routing/sequence_manager.py
+++ b/src/client/routing/sequence_manager.py
@@ -126,7 +126,7 @@ class RemoteSequenceManager(threading.Thread):
             ix = slice(int(ix), int(ix) + 1, 1)
 
         self.ready.wait()
-        with self.sequence_info.lock_changes:
+        with self.lock_changes:
             subseq = RemoteSequenceManager(
                 self.dht,
                 self.block_uids[ix],
@@ -136,13 +136,12 @@ class RemoteSequenceManager(threading.Thread):
             )  # NB: if you've added more parameters to __init__, please forward them in the instantiation above
             subseq.sequence_info = self.sequence_info[ix]
             subseq._rpc_info = self._rpc_info
-            subseq.last_update_time = self.last_update_time
             if self.is_alive():
                 subseq.run_in_background()
         return subseq
 
     def update_(self):
-        with self.sequence_info.lock_changes:
+        with self.lock_changes:
             self.sequence_info.update_(self.dht)
             for name, strategy in self.routing_strategies.items():
                 strategy.update_()

--- a/src/client/routing/sequence_manager.py
+++ b/src/client/routing/sequence_manager.py
@@ -3,25 +3,21 @@ from __future__ import annotations
 import enum
 import random
 import threading
-from typing import List, Optional, Sequence, Tuple, Union
+from typing import Collection, Dict, List, Optional, Sequence, Tuple, Union
 
 from hivemind import DHT, P2P, DHTExpiration, MSGPackSerializer
 from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
 from hivemind.proto import runtime_pb2
 from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 
+from src.client.routing.routing_strategy import ALL_ROUTING_STRATEGIES, RoutingStrategyBase
+from src.client.routing.sequence_info import RemoteSequenceInfo
 from src.data_structures import ModuleUID, RemoteModuleInfo, RemoteSpanInfo, ServerState
 from src.dht_utils import get_remote_module_infos
 from src.server.handler import TransformerConnectionHandler
 
 use_hivemind_log_handler("in_root_logger")
 logger = get_logger(__file__)
-
-
-class RoutingStrategy(enum.Enum):
-    RANDOM = enum.auto()  # choose a random compatible server at each branch and include all layers served by it
-    FASTEST = enum.auto()  # [WIP] minimize the estimated time to process a given number of tokens, including latency
-    LOAD_BALANCED = enum.auto()  # [WIP] use servers in proportion to their speed, on average over many sequences
 
 
 class RemoteSequenceManager(threading.Thread):
@@ -33,6 +29,11 @@ class RemoteSequenceManager(threading.Thread):
     Using this information, sequence manager can form sequences of servers that collectively have the full sequence.
 
     To form such a sequence, call .make_sequence with the appropriate optimization policy (see make_sequence docstr).
+
+    :param dht: a running hivemind.DHT instance, connected to peers that serve the corresponding blocks
+    :param block_uids: a sequence of DHT keys (strings) corresponding to remote layers
+    :param p2p: an optional P2P replica (if not specified, create one via dht.replicate_p2p())
+    :param update_period: by default, refresh DHT information once in this many seconds
 
     :note: RemoteSequenceManager takes up some CPU and network I/O to operate in background. It is recommended to avoid
       running redundant sequence managers for the same set of layers.
@@ -53,71 +54,50 @@ class RemoteSequenceManager(threading.Thread):
         *,
         p2p: Optional[P2P] = None,
         start: bool,
-        max_retries: int = 3,
         update_period: float = 30,
+        routing_strategies: Collection[RoutingStrategyBase] = None,
     ):  # NB: if you add any more parameters, please make sure you pass them to sub-sequences in .__getitem__ below!
         super().__init__(daemon=True)
         self.dht, self.p2p = dht, (p2p if p2p is not None else dht.replicate_p2p())
-        self.block_uids: List[ModuleUID] = list(block_uids)
-        self.block_infos: List[Optional[RemoteModuleInfo]] = [None] * len(self.block_uids)
-        self.spans_by_priority: List[RemoteSpanInfo] = []  # sorted from best to worst
-        self.spans_containing_block: Tuple[List[RemoteSpanInfo], ...] = tuple([] for _ in range(len(self.block_uids)))
+        self.sequence_info = RemoteSequenceInfo.make_empty(block_uids)  # to be updated in a background thread
 
-        self.update_period, self.max_retries = update_period, max_retries
+        if routing_strategies is None:
+            routing_strategies = [Strategy(self.sequence_info) for Strategy in ALL_ROUTING_STRATEGIES]
+        self.routing_strategies: Dict[str, RoutingStrategyBase] = {s.name: s for s in routing_strategies}
+
         self.last_update_time: DHTExpiration = -float("inf")
+        self.update_period = update_period
 
         self._rpc_info = None
         self._lock_changes = threading.Lock()
-        self.ready = threading.Event()  # whether or not this thread is ready to make_sequence
+        self.ready = threading.Event()  # whether or not you are ready to make_sequence
 
         if start:
             self.run_in_background()
 
-        for uid, info in zip(self.block_uids, self.block_infos):
-            assert info is not None, f"Found no remote peers for block {uid}"
-        assert self.spans_by_priority and self.spans_containing_block
+    def run(self) -> None:
+        self.ready.set()
+        # TODO
 
     def make_sequence(
-        self,
-        start_index: int = 0,
-        end_index: Optional[int] = None,
-        strategy: RoutingStrategy = RoutingStrategy.RANDOM,
-        num_tokens: Optional[int] = None,
+        self, strategy: Union[str, RoutingStrategyBase], start_index: int = 0, end_index: Optional[int] = None, **kwargs
     ) -> Sequence[RemoteSpanInfo]:
         """
         Form a sequence of remote servers that collectively serve all consecutive layers
 
+        :param strategy: the routing algorithm to use (e.g. random, fastest, balanced), see routing_strategy.py
         :param start_index: optional index of the first module in a sequence, default = the first of block_uids
         :param end_index: optional index of the last module (non-inclusive), default = after last of block_uids
-        :param strategy: the routing algorithm to use (e.g. random, fastest, balanced), see RoutingStrategy for details
-        :param num_tokens: the number of tokens sent through this sequence at a time, used by RoutingStrategy.FASTEST
+        :param kwargs: additional keyword arguments, depending on your chosen routing strategy
         """
         assert self.is_alive()
         if not self.ready.is_set():
             logger.warning(f"{self.__class__.__name__} is still initializing, waiting until it's ready...")
             self.ready.wait()
             logger.warning(f"Finished waiting for {self.__class__.__name__} to initialize")
-        if (strategy is RoutingStrategy.FASTEST) != (num_tokens is not None):
-            logger.warning("please specify num_tokens with FASTEST strategy (and only with FASTEST strategy)")
-        end_index = end_index if end_index is not None else len(self.block_uids)
-
-        if strategy == RoutingStrategy.RANDOM:
-            span_sequence = []
-            current_index = start_index
-            while current_index < end_index:
-                candidate_spans = self.spans_containing_block[current_index]
-                chosen_span = random.choice(candidate_spans)
-                assert chosen_span.start <= current_index < chosen_span.end
-                span_sequence.append(chosen_span)
-                current_index = chosen_span.end
-            return span_sequence
-        elif strategy == RoutingStrategy.FASTEST:
-            raise NotImplementedError("Fastest routing strategy is not implemented (yet)")
-        elif strategy == RoutingStrategy.LOAD_BALANCED:
-            raise NotImplementedError("Load-balanced routing strategy is not implemented (yet)")
-
-
-
+        if not isinstance(strategy, RoutingStrategyBase):
+            strategy = self.routing_strategies[strategy]
+        return strategy.make_sequence(start_index, end_index, **kwargs)
 
     def __getitem__(self, ix: Union[int, slice]) -> RemoteSequenceManager:
         """Get a RemoteSequenceManager for a sub-sequence of blocks"""
@@ -131,11 +111,10 @@ class RemoteSequenceManager(threading.Thread):
                 self.dht,
                 self.block_uids[ix],
                 p2p=self.p2p,
-                max_retries=self.max_retries,
                 update_period=self.update_period,
                 start=False,
             )  # NB: if you've added more parameters to __init__, please forward them in the instantiation above
-            subseq.block_infos = self.block_infos[ix]
+            subseq.sequence_info = self.sequence_info[ix]
             subseq.spans_by_priority, subseq.spans_containing_block = subseq.compute_spans(subseq.block_infos)
             subseq._rpc_info = self._rpc_info
             subseq.last_update_time = self.last_update_time
@@ -145,8 +124,9 @@ class RemoteSequenceManager(threading.Thread):
 
     def update_(self):
         with self._lock_changes:
-            self.update_block_infos_()
-            self.spans_by_priority, self.spans_containing_block = self.compute_spans(self.block_infos)
+            self.sequence_info.update_(self.dht)
+            for name, strategy in self.routing_strategies:
+                strategy.update_()
 
     def run_in_background(self, await_ready: bool = True, timeout: Optional[float] = None) -> None:
         """
@@ -157,53 +137,16 @@ class RemoteSequenceManager(threading.Thread):
         if await_ready:
             self.ready.wait(timeout)
 
-    def update_block_infos_(self):
-        new_block_infos = get_remote_module_infos(self.dht, self.block_uids, expiration_time=float("inf"))
-        assert len(new_block_infos) == len(self.block_uids)
-        for block_index, (uid, info) in enumerate(zip(self.block_uids, new_block_infos)):
-            if info is None:
-                logger.warning(f"Found no block info for block {uid}")
-            if not isinstance(info, RemoteModuleInfo):
-                logger.warning(f"Unexpected dht entry type for {uid}: {info}")
-            if not info.servers:
-                logger.warning(f"Found no active peers for block {uid}")
-            if info.uid != uid:
-                logger.warning(f"The DHT entry for {uid} actually points to {info.uid}")
-            self.block_infos[block_index] = info
-
-    @staticmethod
-    def compute_spans(block_infos: Sequence[RemoteModuleInfo]):
-        closed_spans = []
-        active_spans = {}
-        for block_index, info in enumerate(block_infos):
-            for peer_id, server in info.servers.items():
-                if server.state != ServerState.ONLINE:
-                    continue
-                if peer_id not in active_spans:
-                    active_spans[peer_id] = RemoteSpanInfo(start=block_index, end=block_index + 1, peer_id=peer_id)
-                else:  # peer_id in active_spans
-                    active_spans[peer_id].end = block_index + 1
-
-            for peer_id in list(active_spans.keys()):
-                if (
-                    peer_id not in info.servers
-                    or info.servers[peer_id].state != ServerState.ONLINE
-                    or block_index == len(block_infos) - 1
-                ):
-                    closed_spans.append(active_spans.pop(peer_id))
-        assert not active_spans
-
-        closed_spans.sort(key=lambda span: span.end - span.start, reverse=True)
-
-        spans_containing_block = tuple(list() for _ in range(len(block_infos)))
-        for span in closed_spans:
-            for block_index in range(span.start, span.end):
-                spans_containing_block[block_index].append(span)
-
-        return closed_spans, spans_containing_block
-
     def __len__(self):
         return len(self.block_uids)
+
+    @property
+    def block_uids(self) -> Sequence[ModuleUID]:
+        return self.sequence_info.block_uids
+
+    @property
+    def block_infos(self) -> Sequence[RemoteModuleInfo]:
+        return self.sequence_info.block_infos
 
     @property
     def rpc_info(self):
@@ -226,3 +169,11 @@ class RemoteSequenceManager(threading.Thread):
                     else:
                         logger.warning(f"Tried to call rpc_info, but caught {repr(e)}", exc_info=True)
         return self._rpc_info
+
+    @property
+    def max_retries(self) -> int:
+        logger.warning(
+            "RemoteSequenceManager.max_retries is deprecated and will be removed when dbaranchuk@ implements"
+            " chained forward/backward. If you have questions about the roadmap, please ping yozh@ ."
+        )
+        return 3

--- a/src/client/sequence_manager.py
+++ b/src/client/sequence_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import enum
 import random
 import threading
 from typing import List, Optional, Sequence, Tuple, Union
@@ -17,64 +18,144 @@ use_hivemind_log_handler("in_root_logger")
 logger = get_logger(__file__)
 
 
-class RemoteSequenceManager:
+class RoutingStrategy(enum.Enum):
+    RANDOM = enum.auto()  # choose a random compatible server at each branch and include all layers served by it
+    FASTEST = enum.auto()  # [WIP] minimize the estimated time to process a given number of tokens, including latency
+    LOAD_BALANCED = enum.auto()  # [WIP] use servers in proportion to their speed, on average over many sequences
+
+
+class RemoteSequenceManager(threading.Thread):
     """
-    Keeps and updates the meta-information about which peers host which blocks.
-    In future, this class is intended to maintain latency statistics, ban non-responsive peers, etc.
+    Sequence manager is a thread that keeps track of information on remote servers that constitute a RemoteSequential.
+    TL;DR it tells you, which peers you should ask to get a specific layer. It is used in RemoteSequential.
+
+    When created, RemoteSequenceManager looks up which servers serve necessary layers by reading from DHT.
+    Using this information, sequence manager can form sequences of servers that collectively have the full sequence.
+
+    To form such a sequence, call .make_sequence with the appropriate optimization policy (see make_sequence docstr).
+
+    :note: RemoteSequenceManager takes up some CPU and network I/O to operate in background. It is recommended to avoid
+      running redundant sequence managers for the same set of layers.
+
+    Example
+    =======
+    >>> sequence_manager = RemoteSequenceManager(dht=..., block_uids=('me/my-model.0', 'me/my-model.1', 'me/my-model.2')
+    >>> seq1_full_model = sequence_manager.make_sequence()
+    >>> seq2_partial = sequence_manager.make_sequence(start_index=0, end_index=2)  # the end index is exclusive
+    >>> seq1_fastest = sequence_manager.make_sequence()
+
     """
 
-    def __init__(self, dht: DHT, block_uids: Sequence[ModuleUID], p2p: P2P, max_retries: int = 3):
-        self.dht, self.p2p = dht, p2p
+    def __init__(
+        self,
+        dht: DHT,
+        block_uids: Sequence[ModuleUID],
+        *,
+        p2p: Optional[P2P] = None,
+        start: bool,
+        max_retries: int = 3,
+        update_period: float = 30,
+    ):  # NB: if you add any more parameters, please make sure you pass them to sub-sequences in .__getitem__ below!
+        super().__init__(daemon=True)
+        self.dht, self.p2p = dht, (p2p if p2p is not None else dht.replicate_p2p())
         self.block_uids: List[ModuleUID] = list(block_uids)
         self.block_infos: List[Optional[RemoteModuleInfo]] = [None] * len(self.block_uids)
         self.spans_by_priority: List[RemoteSpanInfo] = []  # sorted from best to worst
         self.spans_containing_block: Tuple[List[RemoteSpanInfo], ...] = tuple([] for _ in range(len(self.block_uids)))
+
+        self.update_period, self.max_retries = update_period, max_retries
         self.last_update_time: DHTExpiration = -float("inf")
-        self.max_retries = max_retries
+
         self._rpc_info = None
-        self.lock_changes = threading.Lock()
-        self.update_()
+        self._lock_changes = threading.Lock()
+        self.ready = threading.Event()  # whether or not this thread is ready to make_sequence
+
+        if start:
+            self.run_in_background()
 
         for uid, info in zip(self.block_uids, self.block_infos):
             assert info is not None, f"Found no remote peers for block {uid}"
         assert self.spans_by_priority and self.spans_containing_block
 
-    def make_sequence(self, start_index: int = 0, end_index: Optional[int] = None) -> Sequence[RemoteSpanInfo]:
+    def make_sequence(
+        self,
+        start_index: int = 0,
+        end_index: Optional[int] = None,
+        strategy: RoutingStrategy = RoutingStrategy.RANDOM,
+        num_tokens: Optional[int] = None,
+    ) -> Sequence[RemoteSpanInfo]:
         """
         Form a sequence of remote servers that collectively serve all consecutive layers
 
         :param start_index: optional index of the first module in a sequence, default = the first of block_uids
-        :param end_index: optional index of the last module (non-inclusive), default = after last of block uids
+        :param end_index: optional index of the last module (non-inclusive), default = after last of block_uids
+        :param strategy: the routing algorithm to use (e.g. random, fastest, balanced), see RoutingStrategy for details
+        :param num_tokens: the number of tokens sent through this sequence at a time, used by RoutingStrategy.FASTEST
         """
+        assert self.is_alive()
+        if not self.ready.is_set():
+            logger.warning(f"{self.__class__.__name__} is still initializing, waiting until it's ready...")
+            self.ready.wait()
+            logger.warning(f"Finished waiting for {self.__class__.__name__} to initialize")
+        if (strategy is RoutingStrategy.FASTEST) != (num_tokens is not None):
+            logger.warning("please specify num_tokens with FASTEST strategy (and only with FASTEST strategy)")
         end_index = end_index if end_index is not None else len(self.block_uids)
-        span_sequence = []
-        current_index = start_index
-        while current_index < end_index:
-            candidate_spans = self.spans_containing_block[current_index]
-            chosen_span = random.choice(candidate_spans)  # TODO this should be replaced with proper load balancing
 
-            assert chosen_span.start <= current_index < chosen_span.end
-            span_sequence.append(chosen_span)
-            current_index = chosen_span.end
+        if strategy == RoutingStrategy.RANDOM:
+            span_sequence = []
+            current_index = start_index
+            while current_index < end_index:
+                candidate_spans = self.spans_containing_block[current_index]
+                chosen_span = random.choice(candidate_spans)
+                assert chosen_span.start <= current_index < chosen_span.end
+                span_sequence.append(chosen_span)
+                current_index = chosen_span.end
+            return span_sequence
+        elif strategy == RoutingStrategy.FASTEST:
+            raise NotImplementedError("Fastest routing strategy is not implemented (yet)")
+        elif strategy == RoutingStrategy.LOAD_BALANCED:
+            raise NotImplementedError("Load-balanced routing strategy is not implemented (yet)")
 
-        return span_sequence
+
+
 
     def __getitem__(self, ix: Union[int, slice]) -> RemoteSequenceManager:
         """Get a RemoteSequenceManager for a sub-sequence of blocks"""
         assert isinstance(ix, (int, slice))
         if not isinstance(ix, slice):
             ix = slice(int(ix), int(ix) + 1, 1)
-        with self.lock_changes:
-            subseq = RemoteSequenceManager(self.dht, self.block_uids[ix], self.p2p)
+
+        self.ready.wait()
+        with self._lock_changes:
+            subseq = RemoteSequenceManager(
+                self.dht,
+                self.block_uids[ix],
+                p2p=self.p2p,
+                max_retries=self.max_retries,
+                update_period=self.update_period,
+                start=False,
+            )  # NB: if you've added more parameters to __init__, please forward them in the instantiation above
             subseq.block_infos = self.block_infos[ix]
             subseq.spans_by_priority, subseq.spans_containing_block = subseq.compute_spans(subseq.block_infos)
+            subseq._rpc_info = self._rpc_info
             subseq.last_update_time = self.last_update_time
+            if self.is_alive():
+                subseq.run_in_background()
         return subseq
 
     def update_(self):
-        with self.lock_changes:
+        with self._lock_changes:
             self.update_block_infos_()
             self.spans_by_priority, self.spans_containing_block = self.compute_spans(self.block_infos)
+
+    def run_in_background(self, await_ready: bool = True, timeout: Optional[float] = None) -> None:
+        """
+        Starts averager in a background process. if await_ready, this method will wait until background dht
+        is ready to process incoming requests or for :timeout: seconds max.
+        """
+        self.start()
+        if await_ready:
+            self.ready.wait(timeout)
 
     def update_block_infos_(self):
         new_block_infos = get_remote_module_infos(self.dht, self.block_uids, expiration_time=float("inf"))

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -9,7 +9,7 @@ from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
 from hivemind.p2p import StubBase
 from hivemind.utils.nested import nested_compare, nested_flatten, nested_pack
 
-from src.client.sequence_manager import RemoteSequenceManager
+from src.client.routing.sequence_manager import RemoteSequenceManager
 from src.data_structures import CHAIN_DELIMITER, ModuleUID, RemoteSpanInfo, RPCInfo
 from src.server.handler import TransformerConnectionHandler
 

--- a/src/dht_utils.py
+++ b/src/dht_utils.py
@@ -105,7 +105,7 @@ def get_remote_module(
 
 def get_remote_module_infos(
     dht: DHT,
-    uid_or_uids: Union[ModuleUID, List[ModuleUID]],
+    uid_or_uids: Union[ModuleUID, Sequence[ModuleUID]],
     expiration_time: Optional[DHTExpiration] = None,
 ) -> List[Optional[RemoteModuleInfo]]:
     single_uid = isinstance(uid_or_uids, ModuleUID)
@@ -117,7 +117,7 @@ def get_remote_module_infos(
 
 
 async def _get_remote_module_infos(
-    dht: DHT, node: DHTNode, uids: List[ModuleUID], expiration_time: Optional[DHTExpiration]
+    dht: DHT, node: DHTNode, uids: Sequence[ModuleUID], expiration_time: Optional[DHTExpiration]
 ) -> List[Optional[RemoteModuleInfo]]:
     if expiration_time is None:
         expiration_time = get_dht_time()


### PR DESCRIPTION
TODO:
- [x] RemoteSequenceInfo
- [x] RoutingStrategy interface - and forward kwargs from init
- [x] RandomRoutingStrategy
- [ ] change update_ into a background thread, implement RemoteSequenceManager.run
- [ ] move lock_changes from RemoteSequenceManager to RemoteSequenceInfo
- [ ] basic tests for RemoteSequenceManager
- [ ] make it pass tests again
- [ ] move RemoteSequenceManager.rpc_info to RemoteSequenceInfo.rpc_info (make manager.rpc_info point to the new location)
- [ ] change RandomRoutingStrategy to trigger refresh in case there is no path - as opposed to crashing in on_update
- [ ] make some warnings that indicate that the sequence is not ready
- [ ] EFSearchStrategy
- [ ] revert run-tests.html

Things changed in this PR:
- RemoteSequenceManager will now run a **background thread** that looks up DHT entries periodically
  - previously, manager would reload all DHT entries on each RemoteSequential.forward, increasing latency
- RemoteSequenceManager.make_sequence now supports multiple routing strategies


Things beyond the scope of this PR:
- __Load-balanced routing__ will be done in a subsequent PR
- __Routing code decomposition / support for user-defined strategies__ - important, but complicated and not urgent -> later
- __Optimized model init__ - prepare sequence manager in parallel with loading embeddings? save latency and blacklists on disk?
- __Cleaning up src.client file structure__ - there will come a day when we organize the client-side more neatly. But that day is not today.

