### PR TITLE
Reduce vocabulary size in test model, fix bug in routing when overlapped

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -36,8 +36,8 @@ jobs:
           export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
           python -m cli.convert_model --model bigscience/bloom-560m  --output_path ./converted_model \
             --output_repo bloom-testing/test-bloomd-560m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN \
-            --resize_token_embeddings 10_000  # reduce embeddings size to save memory
-
+            --resize_token_embeddings 10000
+          
 
   run-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,12 +26,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Delete test models older than 72 hours
+      - name: Delete any test models older than 72 hours
         run: |
-          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
-          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
-      - name: Delete previous model, if exists
+          python tests/scripts/remove_old_models.py --author bloom-testing --use_auth_token $BLOOM_TESTING_WRITE_TOKEN
+      - name: Delete previous version of this model, if exists
         run: |
           export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
           python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
@@ -109,7 +107,8 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server5.log &
           SERVER5_PID=$!
           
-          #TODO tail server logs
+          tail -n 100 -f server*.log &
+          LOGGER_PID=$!
           sleep 30  # wait for servers to download layers
           
           kill -0 $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID # ensure all servers survived init
@@ -118,5 +117,5 @@ jobs:
           
           kill -0 $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID # ensure all servers survived tests
           
-          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID
+          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID $LOGGER_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,47 +6,46 @@ on:
   pull_request:
 
 jobs:
-#  convert-model:
-#    runs-on: ubuntu-latest
-#    env:
-#      BLOOM_TESTING_WRITE_TOKEN: ${{ secrets.BLOOM_TESTING_WRITE_TOKEN }}
-#    timeout-minutes: 15
-#    steps:
-#      - uses: actions/checkout@v2
-#      - name: Set up Python
-#        uses: actions/setup-python@v2
-#        with:
-#          python-version: 3.9
-#      - name: Cache dependencies
-#        uses: actions/cache@v2
-#        with:
-#          path: ~/.cache/pip
-#          key: Key-v1-py3.9-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
-#      - name: Install dependencies
-#        run: |
-#          python -m pip install --upgrade pip
-#          pip install -r requirements.txt
-#      - name: Delete test models older than 72 hours
-#        run: |
-#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-#          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
-#          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
-#      - name: Delete previous model, if exists
-#        run: |
-#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-#          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
-#          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
-#      - name: Convert model and push to hub
-#        run: |
-#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-#          python -m cli.convert_model --model bigscience/bloom-560m  --output_path ./converted_model \
-#            --output_repo bloom-testing/test-bloomd-560m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN \
-#            --resize_token_embeddings 10000
-          
+  convert-model:
+    runs-on: ubuntu-latest
+    env:
+      BLOOM_TESTING_WRITE_TOKEN: ${{ secrets.BLOOM_TESTING_WRITE_TOKEN }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: Key-v1-py3.9-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Delete test models older than 72 hours
+        run: |
+          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
+          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
+      - name: Delete previous model, if exists
+        run: |
+          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
+          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
+      - name: Convert model and push to hub
+        run: |
+          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+          python -m cli.convert_model --model bigscience/bloom-560m  --output_path ./converted_model \
+            --output_repo bloom-testing/test-bloomd-560m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN \
+            --resize_token_embeddings 50000
 
   run-tests:
     runs-on: ubuntu-latest
-#    needs: convert-model
+    needs: convert-model
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9 ]
@@ -83,7 +82,8 @@ jobs:
           export REF_NAME=bigscience/bloom-560m
 
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:12 \
-            --torch_dtype float32 --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 --throughput 1 &
+            --torch_dtype float32 --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 \
+            --throughput 1 &> server2.log &
           SERVER1_PID=$!
           
           sleep 5  # wait for the first server to initialize DHT
@@ -109,6 +109,7 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
           SERVER5_PID=$!
           
+          #TODO tail server logs
           sleep 30  # wait for servers to download layers
           
           kill -0 $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID # ensure all servers survived init

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           git clone https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
-          git checkout 1ced47c5043ed88b78c288f55f43ec3e66a0f765
+          git checkout 4cd7ea62b2f51c68aacde2f62e7141765e476111
           make cpuonly
           pip install .
           cd -
@@ -108,10 +108,14 @@ jobs:
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --num_blocks 3 \
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
           SERVER5_PID=$!
-
-          sleep 30  # wait for server to download layers
+          
+          sleep 30  # wait for servers to download layers
+          
+          kill -0 $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID # ensure all servers survived init
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v
+          
+          kill -0 $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID # ensure all servers survived tests
           
           kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -90,7 +90,7 @@ jobs:
           export INITIAL_PEERS=/ip4/127.0.0.1/tcp/31337/p2p/QmS9KwZptnVdB9FFV7uGgaTq4sEKBwcYeKZDfSpyKDUd1g
           # ^-- server 1 multiaddr is determined by --identity and --host_maddrs
           
-          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 12:24 \
+          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 12:22 \
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server2.log &
           SERVER2_PID=$!
 
@@ -101,10 +101,16 @@ jobs:
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 4:16 \
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
           SERVER4_PID=$!
+          
+          sleep 10 # wait for initial servers to declare blocks, then let server decide which blocks to serve
 
-          sleep 60  # wait for server to download layers
+          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --num_blocks 3 \
+            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
+          SERVER5_PID=$!
+
+          sleep 30  # wait for server to download layers
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v
           
-          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID
+          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $SERVER5_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,37 +6,37 @@ on:
   pull_request:
 
 jobs:
-  convert-model:
-    runs-on: ubuntu-latest
-    env:
-      BLOOM_TESTING_WRITE_TOKEN: ${{ secrets.BLOOM_TESTING_WRITE_TOKEN }}
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: Key-v1-py3.9-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Delete previous model, if exists
-        run: |
-          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
-          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
-      - name: Convert model and push to hub
-        run: |
-          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
-          python -m cli.convert_model --model bigscience/bloom-560m  --output_path ./converted_model \
-            --output_repo bloom-testing/test-bloomd-560m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN \
-            --resize_token_embeddings 10000
+#  convert-model:
+#    runs-on: ubuntu-latest
+#    env:
+#      BLOOM_TESTING_WRITE_TOKEN: ${{ secrets.BLOOM_TESTING_WRITE_TOKEN }}
+#    timeout-minutes: 15
+#    steps:
+#      - uses: actions/checkout@v2
+#      - name: Set up Python
+#        uses: actions/setup-python@v2
+#        with:
+#          python-version: 3.9
+#      - name: Cache dependencies
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/.cache/pip
+#          key: Key-v1-py3.9-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
+#      - name: Install dependencies
+#        run: |
+#          python -m pip install --upgrade pip
+#          pip install -r requirements.txt
+#      - name: Delete previous model, if exists
+#        run: |
+#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+#          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
+#          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
+#      - name: Convert model and push to hub
+#        run: |
+#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+#          python -m cli.convert_model --model bigscience/bloom-560m  --output_path ./converted_model \
+#            --output_repo bloom-testing/test-bloomd-560m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN \
+#            --resize_token_embeddings 10000
           
 
   run-tests:
@@ -102,5 +102,5 @@ jobs:
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v
           
-          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $LOGS_PID
+          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,6 +26,11 @@ jobs:
 #        run: |
 #          python -m pip install --upgrade pip
 #          pip install -r requirements.txt
+#      - name: Delete test models older than 72 hours
+#        run: |
+#          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
+#          python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
+#          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
 #      - name: Delete previous model, if exists
 #        run: |
 #          export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
@@ -90,17 +95,9 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server2.log &
           SERVER2_PID=$!
 
-          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:6 \
-            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server3.log &
-          SERVER3_PID=$!
-
-          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 4:16 \
-            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
-          SERVER4_PID=$!
-
           sleep 60  # wait for server to download layers
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v
           
-          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID
+          kill -s SIGINT $SERVER1_PID $SERVER2_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         run: |
           git clone https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
-          git checkout de354f7ded52bfa857089769225cdf1ee694bfd6
+          git checkout 1ced47c5043ed88b78c288f55f43ec3e66a0f765
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -90,14 +90,14 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server2.log &
           SERVER2_PID=$!
 
-#          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:6 \
-#            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server3.log &
-#          SERVER3_PID=$!
-#
-#          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 4:16 \
-#            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
-#          SERVER4_PID=$!
-#
+          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:6 \
+            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server3.log &
+          SERVER3_PID=$!
+
+          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 4:16 \
+            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
+          SERVER4_PID=$!
+
           tail -f server*.log &
           LOGS_PID=$!
 
@@ -105,5 +105,5 @@ jobs:
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v
           
-          kill -s SIGINT $SERVER1_PID $SERVER2_PID # $SERVER3_PID $SERVER4_PID $LOGS_PID
+          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID $LOGS_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -41,7 +41,7 @@ jobs:
 
   run-tests:
     runs-on: ubuntu-latest
-    needs: convert-model
+#    needs: convert-model
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9 ]

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -72,6 +72,7 @@ jobs:
         run: |
           git clone https://github.com/TimDettmers/bitsandbytes.git
           cd bitsandbytes
+          git checkout de354f7ded52bfa857089769225cdf1ee694bfd6
           make cpuonly
           pip install .
           cd -

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -82,8 +82,7 @@ jobs:
           export REF_NAME=bigscience/bloom-560m
 
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:12 \
-            --torch_dtype float32 --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 \
-            --throughput 1 &> server1.log
+            --torch_dtype float32 --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 --throughput 1 &
           SERVER1_PID=$!
           
           sleep 5  # wait for the first server to initialize DHT
@@ -95,9 +94,17 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server2.log &
           SERVER2_PID=$!
 
+          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:6 \
+            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server3.log &
+          SERVER3_PID=$!
+
+          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 4:16 \
+            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
+          SERVER4_PID=$!
+
           sleep 60  # wait for server to download layers
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v
           
-          kill -s SIGINT $SERVER1_PID $SERVER2_PID
+          kill -s SIGINT $SERVER1_PID $SERVER2_PID $SERVER3_PID $SERVER4_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -98,9 +98,6 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
           SERVER4_PID=$!
 
-          tail -f server*.log &
-          LOGS_PID=$!
-
           sleep 60  # wait for server to download layers
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-      - name: Delete any test models older than 72 hours
+      - name: Delete any test models older than 1 week
         run: |
           python tests/scripts/remove_old_models.py --author bloom-testing --use_auth_token $BLOOM_TESTING_WRITE_TOKEN
       - name: Delete previous version of this model, if exists

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -35,7 +35,8 @@ jobs:
         run: |
           export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
           python -m cli.convert_model --model bigscience/bloom-560m  --output_path ./converted_model \
-            --output_repo bloom-testing/test-bloomd-560m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN
+            --output_repo bloom-testing/test-bloomd-560m-$HF_TAG --use_auth_token $BLOOM_TESTING_WRITE_TOKEN \
+            --resize_token_embeddings 10_000  # reduce embeddings size to save memory
 
 
   run-tests:
@@ -76,7 +77,8 @@ jobs:
           export REF_NAME=bigscience/bloom-560m
 
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:12 \
-            --torch_dtype float32 --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 --throughput 1 &
+            --torch_dtype float32 --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 \
+            --throughput 1 &> server1.log
           SERVER1_PID=$!
           
           sleep 5  # wait for the first server to initialize DHT
@@ -88,9 +90,20 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server2.log &
           SERVER2_PID=$!
 
+#          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:6 \
+#            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server3.log &
+#          SERVER3_PID=$!
+#
+#          python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 4:16 \
+#            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
+#          SERVER4_PID=$!
+#
+          tail -f server*.log &
+          LOGS_PID=$!
+
           sleep 60  # wait for server to download layers
           
           PYTHONPATH=. pytest tests --durations=0 --durations-min=1.0 -v
           
-          kill -s SIGINT $SERVER1_PID $SERVER2_PID
+          kill -s SIGINT $SERVER1_PID $SERVER2_PID # $SERVER3_PID $SERVER4_PID $LOGS_PID
           echo "Done!"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -83,7 +83,7 @@ jobs:
 
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:12 \
             --torch_dtype float32 --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 \
-            --throughput 1 &> server2.log &
+            --throughput 1 &> server1.log &
           SERVER1_PID=$!
           
           sleep 5  # wait for the first server to initialize DHT
@@ -95,6 +95,8 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server2.log &
           SERVER2_PID=$!
 
+          sleep 10 # wait for initial servers to declare blocks, then let server decide which blocks to serve
+
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:6 \
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server3.log &
           SERVER3_PID=$!
@@ -103,10 +105,8 @@ jobs:
             --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
           SERVER4_PID=$!
           
-          sleep 10 # wait for initial servers to declare blocks, then let server decide which blocks to serve
-
           python -m cli.run_server --converted_model_name_or_path $MODEL_NAME --num_blocks 3 \
-            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server4.log &
+            --torch_dtype float32 --initial_peers $INITIAL_PEERS --throughput 1 &> server5.log &
           SERVER5_PID=$!
           
           #TODO tail server logs

--- a/cli/convert_model.py
+++ b/cli/convert_model.py
@@ -60,6 +60,7 @@ if __name__ == "__main__":
     if args.resize_token_embeddings:
         logger.info(f"Resizing token embeddings, new size = {args.resize_token_embeddings}")
         model.resize_token_embeddings(args.resize_token_embeddings)
+        config.vocab_size = args.resize_token_embeddings
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         args.model, use_auth_token=args.use_auth_token, revision=args.revision

--- a/cli/convert_model.py
+++ b/cli/convert_model.py
@@ -35,8 +35,7 @@ if __name__ == "__main__":
         "--commit_message", type=str, default="push-o-matic", help="Use this commit message for all parts"
     )
     parser.add_argument("--use_auth_token", type=str, default=None, help="auth token for from_pretrained")
-    parser.add_argument("--resize_token_embeddings", type=int, default=None,
-                        help="change the vocabulary size of the converted model to this value")
+    parser.add_argument("--resize_token_embeddings", type=int, default=None, help="change the vocabulary size")
     args = parser.parse_args()
 
     free_ram_gb = psutil.virtual_memory().available / 2**30

--- a/cli/convert_model.py
+++ b/cli/convert_model.py
@@ -35,6 +35,8 @@ if __name__ == "__main__":
         "--commit_message", type=str, default="push-o-matic", help="Use this commit message for all parts"
     )
     parser.add_argument("--use_auth_token", type=str, default=None, help="auth token for from_pretrained")
+    parser.add_argument("--resize_token_embeddings", type=int, default=None,
+                        help="change the vocabulary size of the converted model to this value")
     args = parser.parse_args()
 
     free_ram_gb = psutil.virtual_memory().available / 2**30
@@ -56,6 +58,10 @@ if __name__ == "__main__":
     model = BloomModel.from_pretrained(
         args.model, use_auth_token=args.use_auth_token, revision=args.revision, torch_dtype=DTYPE_MAP[args.torch_dtype]
     )
+    if args.resize_token_embeddings:
+        logger.info(f"Resizing token embeddings, new size = {args.resize_token_embeddings}")
+        model.resize_token_embeddings(args.resize_token_embeddings)
+
     tokenizer = transformers.AutoTokenizer.from_pretrained(
         args.model, use_auth_token=args.use_auth_token, revision=args.revision
     )

--- a/src/client/sequence_manager.py
+++ b/src/client/sequence_manager.py
@@ -54,7 +54,7 @@ class RemoteSequenceManager:
             chosen_span = random.choice(candidate_spans)  # TODO this should be replaced with proper load balancing
 
             assert chosen_span.start <= current_index < chosen_span.end
-            span_sequence.append(chosen_span)
+            span_sequence.append(RemoteSpanInfo(start=current_index, end=chosen_span.end, peer_id=chosen_span.peer_id))
             current_index = chosen_span.end
 
         return span_sequence

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -191,6 +191,7 @@ async def sequential_backward(
 
     # For now, we do not support mixed dummy and grad prompts
     # Concat in num_layer dimension
+    assert not grad_prompts_reversed or len(grad_prompts_reversed) == len(prompts)
     grad_prompts = torch.cat(grad_prompts_reversed[::-1], dim=0) if grad_prompts_reversed else None
     return grad_outputs, grad_prompts
 

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -191,7 +191,6 @@ async def sequential_backward(
 
     # For now, we do not support mixed dummy and grad prompts
     # Concat in num_layer dimension
-    assert not grad_prompts_reversed or len(grad_prompts_reversed) == len(prompts)
     grad_prompts = torch.cat(grad_prompts_reversed[::-1], dim=0) if grad_prompts_reversed else None
     return grad_outputs, grad_prompts
 

--- a/tests/scripts/remove_old_models.py
+++ b/tests/scripts/remove_old_models.py
@@ -1,0 +1,25 @@
+import argparse
+import os
+from datetime import datetime
+from huggingface_hub import delete_repo, list_models
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Remove old testing models from HF hub")
+    parser.add_argument("--author", type=str, default='bloom-testing', help="auth token for from_pretrained")
+    parser.add_argument("--seconds_since_last_updated", type=int, default=7 * 24 * 60 * 60)
+    parser.add_argument("--use_auth_token", type=str, default=None, help="auth token for from_pretrained")
+    parser.add_argument('--dry_run', action='store_true')
+
+    args = parser.parse_args()
+
+    for model in list_models(author=args.author, full=True):
+        last_modified = datetime.strptime(model.lastModified, "%Y-%m-%dT%H:%M:%S.%fZ")
+
+        if model.Id.endswith("-main") or "/test-" not in model.Id:
+            continue  # remove only test models
+
+        if (datetime.now() - last_modified).total_seconds() > args.seconds_since_last_updated:
+            if args.dry_run:
+                print(f"{model.Id} can be deleted")
+            else:
+                delete_repo(token=args.use_auth_token, name=model.Id, organization=args.author)

--- a/tests/scripts/remove_old_models.py
+++ b/tests/scripts/remove_old_models.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
     for model in list_models(author=args.author, full=True):
         last_modified = datetime.strptime(model.lastModified, "%Y-%m-%dT%H:%M:%S.%fZ")
 
-        if model.modelId.endswith("-main") or "/test-" not in model.Id:
+        if model.modelId.endswith("-main") or "/test-" not in model.modelId:
             continue  # remove only test models
 
         if (datetime.now() - last_modified).total_seconds() > args.seconds_since_last_updated:

--- a/tests/scripts/remove_old_models.py
+++ b/tests/scripts/remove_old_models.py
@@ -1,25 +1,25 @@
 import argparse
-import os
 from datetime import datetime
+
 from huggingface_hub import delete_repo, list_models
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Remove old testing models from HF hub")
-    parser.add_argument("--author", type=str, default='bloom-testing', help="auth token for from_pretrained")
+    parser.add_argument("--author", type=str, default="bloom-testing", help="auth token for from_pretrained")
     parser.add_argument("--seconds_since_last_updated", type=int, default=7 * 24 * 60 * 60)
     parser.add_argument("--use_auth_token", type=str, default=None, help="auth token for from_pretrained")
-    parser.add_argument('--dry_run', action='store_true')
+    parser.add_argument("--dry_run", action="store_true")
 
     args = parser.parse_args()
 
     for model in list_models(author=args.author, full=True):
         last_modified = datetime.strptime(model.lastModified, "%Y-%m-%dT%H:%M:%S.%fZ")
 
-        if model.Id.endswith("-main") or "/test-" not in model.Id:
+        if model.modelId.endswith("-main") or "/test-" not in model.Id:
             continue  # remove only test models
 
         if (datetime.now() - last_modified).total_seconds() > args.seconds_since_last_updated:
             if args.dry_run:
-                print(f"{model.Id} can be deleted")
+                print(f"{model.modelId} can be deleted")
             else:
-                delete_repo(token=args.use_auth_token, name=model.Id, organization=args.author)
+                delete_repo(token=args.use_auth_token, name=model.modelId, organization=args.author)


### PR DESCRIPTION
More than half of the test 560m model parameters is it's embedding layer (250_880 x 1024).
This adds 1-2 GB of RAM depending on the test scenario
This PR reduces this vocabulary size to save memory during conversion, keeping only the first 50k tokens

As a result,
* tests that load client-side embeddings need significantly less RAM
* we can now run CI tests with 4 servers instead of 2 - needed to test routing - see bugs uncovered
* some of the servers now use load balancing
* CI convert_model now takes 4-5 minutes (was 6-7)

Running CI with 4 servers uncovered a bug:
https://github.com/bigscience-workshop/petals/runs/7879399020?check_suite_focus=true
which is now also fixed


This PR also temporarily pins an older bnb version, pending @TimDettmers 's fix for cpuonly