### PR TITLE
Make inference, forward, and backward fully fault-tolerant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ accelerate==0.10.0
 huggingface-hub==0.7.0
 transformers==4.21.3
 protobuf>=3.12.2,<4.0.0
-git+https://github.com/learning-at-home/hivemind@94c985d2dc7a79a091e46c755e9f2f4469b164c7
+git+https://github.com/learning-at-home/hivemind@8f258b4b3688f671208bf323359cb967b25d640a
 humanfriendly

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -1,4 +1,4 @@
-from src.client.inference_session import RemoteSequentialInferenceSession, RemoteServerInferenceSession
+from src.client.inference_session import RemoteSequentialInferenceSession
 from src.client.remote_model import DistributedBloomConfig, DistributedBloomForCausalLM, DistributedBloomModel
 from src.client.remote_sequential import RemoteSequential, RemoteTransformerBlock
 from src.client.sequence_manager import RemoteSequenceManager

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -1,4 +1,4 @@
-from src.client.inference_session import RemoteSequentialInferenceSession
+from src.client.inference_session import InferenceSession
 from src.client.remote_model import DistributedBloomConfig, DistributedBloomForCausalLM, DistributedBloomModel
 from src.client.remote_sequential import RemoteSequential, RemoteTransformerBlock
 from src.client.sequence_manager import RemoteSequenceManager

--- a/src/client/__init__.py
+++ b/src/client/__init__.py
@@ -1,4 +1,4 @@
-from src.client.inference_session import RemoteSequentialInferenceSession, RemoteTransformerBlockInferenceSession
+from src.client.inference_session import RemoteSequentialInferenceSession, RemoteServerInferenceSession
 from src.client.remote_model import DistributedBloomConfig, DistributedBloomForCausalLM, DistributedBloomModel
 from src.client.remote_sequential import RemoteSequential, RemoteTransformerBlock
 from src.client.sequence_manager import RemoteSequenceManager

--- a/src/client/inference_session.py
+++ b/src/client/inference_session.py
@@ -258,10 +258,13 @@ class InferenceSession:
                         self._chosen_spans[server_idx : server_idx + 1] = updated_spans
                         self._server_sessions[server_idx : server_idx + 1] = updated_sessions
                         recovery_inputs = self._server_inputs[server_idx] if server_idx < n_prev_spans else None
-                        self._server_inputs[server_idx : server_idx + 1] = [recovery_inputs] + [None] * (len(updated_spans) - 1)
-                        assert len(self._chosen_spans) == len(self._server_sessions) == len(self._server_inputs), \
-                            f"Broken state: {len(self._chosen_spans)} spans, {len(self._server_sessions)} sessions, " \
+                        self._server_inputs[server_idx : server_idx + 1] = [recovery_inputs] + [None] * (
+                            len(updated_spans) - 1
+                        )
+                        assert len(self._chosen_spans) == len(self._server_sessions) == len(self._server_inputs), (
+                            f"Broken state: {len(self._chosen_spans)} spans, {len(self._server_sessions)} sessions, "
                             f"{len(self._server_inputs)} inputs"
+                        )
 
                     session = self._server_sessions[server_idx]
                     span = self._chosen_spans[server_idx]
@@ -272,9 +275,10 @@ class InferenceSession:
                         self._server_inputs[server_idx] = torch.cat(
                             [self._server_inputs[server_idx], inputs[:, -n_input_tokens:]], dim=1
                         )
-                    assert self._server_inputs[server_idx].shape[1] == self._position + n_input_tokens, \
-                        f"Broken input cache: server_idx={server_idx} shape={self._server_inputs[server_idx].shape} " \
+                    assert self._server_inputs[server_idx].shape[1] == self._position + n_input_tokens, (
+                        f"Broken input cache: server_idx={server_idx} shape={self._server_inputs[server_idx].shape} "
                         f"position={self._position} n_input_tokens={n_input_tokens}"
+                    )
 
                     if not session.stepped:
                         inputs = self._server_inputs[server_idx]  # Pass full inputs including prefix
@@ -282,8 +286,9 @@ class InferenceSession:
                         inputs = inputs[:, -n_input_tokens:]  # No need to pass prefix further
 
                     outputs = session.step(inputs, prompts[span.start : span.end], **kwargs)
-                    assert inputs.shape == outputs.shape, \
-                        f"Shape mismatch: inputs.shape={inputs.shape}, outputs.shape={outputs.shape})"
+                    assert (
+                        inputs.shape == outputs.shape
+                    ), f"Shape mismatch: inputs.shape={inputs.shape}, outputs.shape={outputs.shape})"
 
                     inputs = outputs
                     server_idx += 1

--- a/src/client/inference_session.py
+++ b/src/client/inference_session.py
@@ -80,7 +80,7 @@ class _ServerInferenceSession:
         new_hidden_states: torch.Tensor,
         prompts: Optional[torch.Tensor] = None,
         hypo_ids: Optional[torch.Tensor] = None,
-    ):
+    ) -> torch.Tensor:
         """
         Inference step: send a chunk of input tesors and receive a chunk of outputs
         :prompts: optional DEEP prompts, added to a prefix of each layer's outputs,
@@ -203,11 +203,11 @@ class InferenceSession:
             except Exception:
                 logger.debug("Caught exception while closing connection to server:", exc_info=True)
 
-    def __enter__(self):
+    def __enter__(self) -> "InferenceSession":
         assert not self._closed and not self._chosen_spans
         return self
 
-    def step(self, inputs: torch.Tensor, prompts: Optional[torch.Tensor] = None, **kwargs):
+    def step(self, inputs: torch.Tensor, prompts: Optional[torch.Tensor] = None, **kwargs) -> torch.Tensor:
         assert not self._closed
         if torch.is_grad_enabled():
             logger.warning("Running inference session with grad enabled. Gradients will *not* be propagated correctly.")

--- a/src/client/inference_session.py
+++ b/src/client/inference_session.py
@@ -159,7 +159,7 @@ class _ServerInferenceSession:
         self.close()
 
 
-class RemoteSequentialInferenceSession:
+class InferenceSession:
     """
     An interface to a multi-step *inference* session for a sequence of remote transformer blocks
     """

--- a/src/client/inference_session.py
+++ b/src/client/inference_session.py
@@ -181,8 +181,11 @@ class InferenceSession:
             span_uids = CHAIN_DELIMITER.join(self._sequence_manager.block_uids[span.start : span.end])
             session = RemoteExpertWorker.run_coroutine(
                 _ServerInferenceSession.create(
-                    stub, span_uids, rpc_info=self._sequence_manager.rpc_info, timeout=self._sequence_manager.timeout,
-                    **self._metadata
+                    stub,
+                    span_uids,
+                    rpc_info=self._sequence_manager.rpc_info,
+                    timeout=self._sequence_manager.timeout,
+                    **self._metadata,
                 )
             )
             server_sessions.append(session)
@@ -223,7 +226,7 @@ class InferenceSession:
                             self._exit_server_sessions(self._server_sessions[server_idx:], verbose=False)
                             self._server_sessions[server_idx:] = []
                             self._chosen_spans[server_idx:] = []
-                            self._server_inputs[server_idx + 1:] = []
+                            self._server_inputs[server_idx + 1 :] = []
 
                             self._sequence_manager.update_()
                             recovery_mode = True

--- a/src/client/inference_session.py
+++ b/src/client/inference_session.py
@@ -278,7 +278,7 @@ class InferenceSession:
                     block_idx = span.end
                     break
                 except Exception as e:
-                    delay = self._sequence_manager.min_backoff * 2**attempt_no
+                    delay = self._sequence_manager.get_retry_delay(attempt_no)
                     logger.warning(
                         f"Caught exception when running inference from block {block_idx} "
                         f"(retry in {delay:.0f} sec): {repr(e)}"

--- a/src/client/remote_sequential.py
+++ b/src/client/remote_sequential.py
@@ -8,7 +8,7 @@ from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
 from torch import nn
 
 import src
-from src.client.inference_session import RemoteSequentialInferenceSession
+from src.client.inference_session import InferenceSession
 from src.client.sequence_manager import RemoteSequenceManager
 from src.client.sequential_autograd import _RemoteSequentialAutogradFunction
 from src.data_structures import UID_DELIMITER
@@ -80,9 +80,9 @@ class RemoteSequential(nn.Module):
     def __len__(self):
         return len(self.sequence_manager)
 
-    def inference_session(self, **kwargs) -> RemoteSequentialInferenceSession:
+    def inference_session(self, **kwargs) -> InferenceSession:
         self.sequence_manager.update_()
-        return RemoteSequentialInferenceSession(self.sequence_manager, self.p2p, **kwargs)
+        return InferenceSession(self.sequence_manager, self.p2p, **kwargs)
 
     def extra_repr(self) -> str:
         return f"modules={self.sequence_manager.block_uids[0]}..{self.sequence_manager.block_uids[-1]}"

--- a/src/client/sequence_manager.py
+++ b/src/client/sequence_manager.py
@@ -160,3 +160,8 @@ class RemoteSequenceManager:
                     else:
                         logger.warning(f"Tried to call rpc_info, but caught {repr(e)}", exc_info=True)
         return self._rpc_info
+
+    def get_retry_delay(self, attempt_no: int) -> float:
+        if attempt_no == 0:
+            return 0
+        return self.min_backoff * 2 ** (attempt_no - 1)

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -3,17 +3,20 @@ A PyTorch autograd function that runs forward/backward on a sequence of remote s
 """
 import asyncio
 import itertools
-import logging
+from collections import deque
 from typing import List, Optional, Sequence, Tuple
 
 import torch
 from hivemind.moe.client.remote_expert_worker import RemoteExpertWorker
+from hivemind.utils.logging import get_logger
 
 from src.client.remote_forward_backward import run_remote_backward, run_remote_forward
 from src.client.sequence_manager import RemoteSequenceManager
 from src.data_structures import CHAIN_DELIMITER, RemoteSpanInfo
 from src.server.handler import TransformerConnectionHandler
 from src.utils.misc import DUMMY, is_dummy
+
+logger = get_logger(__file__)
 
 MAX_TOKENS_IN_BATCH = 1024
 
@@ -39,16 +42,25 @@ async def sequential_forward(
         sequence_manager.block_uids
     )  # should be n_layers - 1 but add extra prompts for convenience
 
-    sequences = sequence_manager.make_sequence(start_index, end_index)
+    sequences = deque()
     intermediate_inputs = []
     done_sequences = []
     outputs = inputs
 
-    while len(sequences) > 0:
+    block_idx = start_index
+    while block_idx < len(sequence_manager):
         for attempt_no in itertools.count():
-            span = sequences.pop(0)
-            span_uids: str = CHAIN_DELIMITER.join(sequence_manager.block_uids[span.start : span.end])
+            logger.debug(f"Forward: block {block_idx}, attempt {attempt_no}")
             try:
+                if attempt_no >= 1:
+                    sequence_manager.update_()
+                if not sequences or attempt_no >= 1:
+                    sequences = deque(sequence_manager.make_sequence(block_idx, end_index))
+                    logger.debug(f"Found path from block {block_idx} via {len(sequences)} servers")
+
+                span = sequences.popleft()
+                span_uids = CHAIN_DELIMITER.join(sequence_manager.block_uids[span.start : span.end])
+
                 stub = TransformerConnectionHandler.get_stub(sequence_manager.p2p, span.peer_id)
                 inputs_and_prompts = [inputs, prompts[span.start : span.end]]
 
@@ -64,14 +76,16 @@ async def sequential_forward(
                 done_sequences.append(span)
 
                 inputs = outputs
+                block_idx = span.end
                 break
             except Exception as e:
-                logging.warning(f"Caught {e} when running forward for chain {span.start}-{span.end}", exc_info=True)
-                await asyncio.sleep(sequence_manager.min_backoff * 2**attempt_no)
-
-                backup_sequences = sequence_manager.make_sequence(span.start)
-                assert backup_sequences[0].start == span.start
-                sequences = backup_sequences
+                delay = sequence_manager.min_backoff * 2**attempt_no
+                logger.warning(
+                    f"Caught exception when running forward from block {block_idx} "
+                    f"(retry in {delay:.0f} sec): {repr(e)}"
+                )
+                logger.debug("See detailed traceback below:", exc_info=True)
+                await asyncio.sleep(delay)
 
     return outputs, intermediate_inputs, done_sequences
 
@@ -110,7 +124,7 @@ async def sequential_backward(
                 grad_prompts_reversed.extend(span_grad_prompts)
                 break
             except Exception as e:
-                logging.warning(f"Caught {e} when running backward for chain {span.start}-{span.end}", exc_info=True)
+                logger.warning(f"Caught {e} when running backward for chain {span.start}-{span.end}", exc_info=True)
                 await asyncio.sleep(sequence_manager.min_backoff * 2**attempt_no)
 
                 _, backup_intermediate_inputs, backup_forward_sequences = await sequential_forward(

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -81,7 +81,7 @@ async def sequential_forward(
                 block_idx = span.end
                 break
             except Exception as e:
-                delay = sequence_manager.min_backoff * 2**attempt_no
+                delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(
                     f"Caught exception when running forward from block {block_idx} "
                     f"(retry in {delay:.0f} sec): {repr(e)}"
@@ -141,7 +141,7 @@ async def sequential_backward(
                 grad_prompts_reversed.extend(span_grad_prompts)
                 break
             except Exception as e:
-                delay = sequence_manager.min_backoff * 2**attempt_no
+                delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(
                     f"Caught exception when running backward between blocks {span.start}-{span.end} "
                     f"(retry in {delay:.0f} sec): {repr(e)}"

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -48,7 +48,7 @@ async def sequential_forward(
     outputs = inputs
 
     block_idx = start_index
-    while block_idx < len(sequence_manager):
+    while block_idx < end_index:
         for attempt_no in itertools.count():
             logger.debug(f"Forward: block {block_idx}, attempt {attempt_no}")
             try:

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -123,7 +123,6 @@ async def sequential_backward(
                     forward_sequences.extend(backup_sequences)
                     inputs = intermediate_inputs.pop()
                     span = forward_sequences.pop()
-                    break
 
                 span_uids = CHAIN_DELIMITER.join(sequence_manager.block_uids[span.start : span.end])
                 stub = TransformerConnectionHandler.get_stub(sequence_manager.p2p, span.peer_id)

--- a/src/client/sequential_autograd.py
+++ b/src/client/sequential_autograd.py
@@ -56,7 +56,9 @@ async def sequential_forward(
                     sequence_manager.update_()
                 if not sequences or attempt_no >= 1:
                     sequences = deque(sequence_manager.make_sequence(block_idx, end_index))
-                    logger.debug(f"Found path from block {block_idx} via {len(sequences)} servers")
+                    # make_sequence() could return a longer sequence
+                    sequences[-1].end = min(sequences[-1].end, end_index)
+                    logger.debug(f"Found path from block {block_idx} to {end_index} via {len(sequences)} servers")
 
                 span = sequences.popleft()
 

--- a/tests/test_block_exact_match.py
+++ b/tests/test_block_exact_match.py
@@ -33,7 +33,7 @@ def test_remote_block_exact_match(atol_forward=1e-5, atol_inference=1e-3):
                 outputs_inference.append(sess.step(inputs[:, i : i + 1, :]))
 
             # test that max length is respected
-            with pytest.raises(P2PHandlerError) as exc_info:
+            with pytest.raises(ValueError, match=r"Maximum length exceeded") as exc_info:
                 sess.step(inputs[:, -1:, :])
             assert "Maximum length exceeded" in repr(exc_info.value)
 


### PR DESCRIPTION
In this PR:

1. **The inference session is made fully fault-tolerant.** If a server fails (or doesn't respond within timeout), it will be replaced by one (or more) servers, and the lost attention caches will be regenerated. See the screenshot of how it works below.

    Here, the 24-layer model is spread across 3 servers, then the intermediate one (holding blocks 8-14) leaves, then a new large server joins and decides to host layers 6-24 (thus closing the gap). The inference session is able to recover the span 8-14 through the new server and successfully continues inference. The results are identical to the ones without failures:

    <img width="1432" alt="Screenshot 2022-11-26 at 08 10 49" src="https://user-images.githubusercontent.com/8748943/204073193-3b27fb4f-a53b-458d-9e42-44e178455468.png">

2. **Forward and backward are made "gap-tolerant".** If some servers leave and a gap arises in the swarm (i.e., some blocks are not handled by anyone), the forward and backward pass will not fail anymore. Instead, they will keep retrying until a new path through the model is available. I have checked that the activations/gradients calculated after failure recovery are equal to the ones calculated without failures.

3. **Fixed an important bug in forward/backward.** Sometimes, `make_sequence()` returns a sequence that is longer than requested (since the last server hosts blocks further than `end_index`). Before this PR, the code actually run the inputs through these extra blocks leading to incorrect results. This affected partial forward passes and partial/full backward passes (since they re-run partial forward passes in case of failures).

4. minor: **Renamed classes:**

    - `RemoteTransformerBlockInferenceSession ` -> `_ServerInferenceSession` (since **(a)** it actually handles the whole span instead of a single block and **(b)** it is not designed to be used outside Petals internals)
    - `RemoteSequentialInferenceSession` -> `InferenceSession` (since the previous name is too long and hardly readable)

5. While working on this PR, I have also discovered a bug in hivemind that leads to an error in Petals. As soon as it is fixed, we should update `requirements.txt` to point to a new hivemind version. See https://github.com/learning-at-home/hivemind/pull/521