### PR TITLE
Make server use smart defaults

### DIFF
--- a/src/petals/cli/run_prod_server.sh
+++ b/src/petals/cli/run_prod_server.sh
@@ -5,8 +5,5 @@ export HIVEMIND_COLORS=true
 while true; do
         pkill -f p2p
         pkill -f run_server
-        python -m petals.cli.run_server bigscience/bloom-petals \
-                --block_indices $1 \
-                --torch_dtype bfloat16 --load_in_8bit \
-                --attn_cache_size $2 2>&1 | tee log_`date '+%F_%H:%M:%S'`
+        python -m petals.cli.run_server bigscience/bloom-petals "$@" 2>&1 | tee log_`date '+%F_%H:%M:%S'`
 done

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -76,11 +76,11 @@ def main():
     parser.add_argument('--expiration', type=float, required=False, default=None,
                         help='DHT entries will expire after this many seconds')
     parser.add_argument('--request_timeout', type=float, required=False, default=3 * 60,
-                        help='Timeout for the whole rpc_forward/rpc_backward/rpc_forward_stream/rpc_backward_stream request')
-    parser.add_argument('--session_timeout', type=float, required=False, default=30 * 60,
-                        help='Timeout for the whole inference session')
+                        help='Timeout (in seconds) for the whole rpc_forward/rpc_backward/rpc_forward_stream/rpc_backward_stream request')
+    parser.add_argument('--session_timeout', type=float, required=False, default=60,
+                        help='Timeout (in seconds) for the whole inference session')
     parser.add_argument('--step_timeout', type=float, required=False, default=5 * 60,
-                        help="Timeout for waiting the next step's inputs inside an inference session")
+                        help="Timeout (in seconds) for waiting the next step's inputs inside an inference session")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--initial_peers', type=str, nargs='*', required=False, default=PUBLIC_INITIAL_PEERS,

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -106,7 +106,8 @@ def main():
                         help="Check the swarm's balance every N seconds (and rebalance it if necessary)")
 
     parser.add_argument("--use_auth_token", type=str, default=None, help="auth token for from_pretrained")
-    parser.add_argument('--load_in_8bit', action='store_true', help='Convert the loaded model into mixed-8bit quantized model.')
+    parser.add_argument('--load_in_8bit', type=bool, default=None,
+                        help="Convert the loaded model into mixed-8bit quantized model. Default: True if GPU is available")
 
     # fmt:on
     args = vars(parser.parse_args())

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -79,9 +79,9 @@ def main():
                         help='DHT entries will expire after this many seconds')
     parser.add_argument('--request_timeout', type=float, required=False, default=3 * 60,
                         help='Timeout (in seconds) for the whole rpc_forward/rpc_backward/rpc_forward_stream/rpc_backward_stream request')
-    parser.add_argument('--session_timeout', type=float, required=False, default=60,
+    parser.add_argument('--session_timeout', type=float, required=False, default=30 * 60,
                         help='Timeout (in seconds) for the whole inference session')
-    parser.add_argument('--step_timeout', type=float, required=False, default=5 * 60,
+    parser.add_argument('--step_timeout', type=float, required=False, default=60,
                         help="Timeout (in seconds) for waiting the next step's inputs inside an inference session")
 
     group = parser.add_mutually_exclusive_group()

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -55,8 +55,10 @@ def main():
                         help="Use this dtype to store block weights and do computations. "
                              "By default, respect the dtypes in the pre-trained state dict.")
     parser.add_argument('--attn_cache_size', type=str, default=None,
-                        help='The size of GPU memory allocated for storing past attention keys/values between inference'
-                             ' steps; examples: 500MB or 1.2GB or 1073741824 (bytes); be warned: 1KB != 1KiB')
+                        help='The size of GPU memory allocated for storing past attention keys/values between inference steps. '
+                             'Examples: 500MB, 1.2GB, 1073741824 (bytes). Note that 1KB != 1KiB here. '
+                             'Default: 0.5GiB * num_blocks * hidden_size / 14336. '
+                             'The latter is the hidden size of the bigscience/bloom-petals model.')
     parser.add_argument('--alloc_timeout', type=float, default=60,
                         help='If the cache is full, the server will wait for this number of seconds hoping that some memory will be freed '
                              'before rejecting the request')

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -64,7 +64,7 @@ class Server:
         expiration: Optional[float] = None,
         request_timeout: float = 3 * 60,
         session_timeout: float = 30 * 60,
-        step_timeout: float = 5 * 60,
+        step_timeout: float = 60,
         prefetch_batches: int = 1,
         sender_threads: int = 1,
         balance_quality: float = 0.75,

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -118,7 +118,7 @@ class Server:
         self.device = device
 
         if load_in_8bit is None:
-            load_in_8bit = (device.type == "cuda")
+            load_in_8bit = device.type == "cuda"
         if load_in_8bit:
             logger.info("Model weights will be loaded in 8-bit format")
         self.load_in_8bit = load_in_8bit

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -119,6 +119,8 @@ class Server:
 
         if load_in_8bit is None:
             load_in_8bit = (device.type == "cuda")
+        if load_in_8bit:
+            logger.info("Model weights will be loaded in 8-bit format")
         self.load_in_8bit = load_in_8bit
 
         self.block_config = BloomConfig.from_pretrained(


### PR DESCRIPTION
Summary:

```python
parser.add_argument('--attn_cache_size', type=str, default=None,
                    help='The size of GPU memory allocated for storing past attention keys/values between inference steps. '
                         'Examples: 500MB, 1.2GB, 1073741824 (bytes). Note that 1KB != 1KiB here. '
                         'Default: 0.5GiB * num_blocks * hidden_size / 14336. '
                         'The latter is the hidden size of the bigscience/bloom-petals model.')

parser.add_argument('--request_timeout', type=float, required=False, default=3 * 60,
                    help='Timeout (in seconds) for the whole rpc_forward/rpc_backward/rpc_forward_stream/rpc_backward_stream request')
parser.add_argument('--session_timeout', type=float, required=False, default=30 * 60,
                    help='Timeout (in seconds) for the whole inference session')
parser.add_argument('--step_timeout', type=float, required=False, default=60,
                    help="Timeout (in seconds) for waiting the next step's inputs inside an inference session")

parser.add_argument('--load_in_8bit', type=bool, default=None,
                    help="Convert the loaded model into mixed-8bit quantized model. Default: True if GPU is available")
```