### PR TITLE
Remove "-r" when installing Petals in examples

### DIFF
--- a/examples/prompt-tuning-personachat.ipynb
+++ b/examples/prompt-tuning-personachat.ipynb
@@ -36,7 +36,7 @@
     "import subprocess\n",
     "import sys\n",
     "\n",
-    "!pip install -r git+https://github.com/bigscience-workshop/petals\n",
+    "!pip install git+https://github.com/bigscience-workshop/petals\n",
     "!pip install datasets wandb\n",
     "\n",
     "IN_COLAB = 'google.colab' in sys.modules\n",

--- a/examples/prompt-tuning-sst2.ipynb
+++ b/examples/prompt-tuning-sst2.ipynb
@@ -36,7 +36,7 @@
     "import subprocess\n",
     "import sys\n",
     "\n",
-    "!pip install -r git+https://github.com/bigscience-workshop/petals\n",
+    "!pip install git+https://github.com/bigscience-workshop/petals\n",
     "!pip install datasets wandb\n",
     "\n",
     "IN_COLAB = 'google.colab' in sys.modules\n",


### PR DESCRIPTION
Passing "-r" to pip in examples is incorrect, as it makes pipe expect a requirements file instead of a package:
`ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'git+https://github.com/bigscience-workshop/petals'`

Without this flag, the installation works:
<img width="636" alt="image" src="https://user-images.githubusercontent.com/16766985/205398493-27c422da-f10c-44da-82ba-2bb99712157f.png">
