### PR TITLE
Add checks for forward() inputs on the client side

### DIFF
--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -53,7 +53,7 @@ class RemoteSequential(nn.Module):
             self.is_subsequence = self.sequence_manager.sequence_info.block_uids != block_uids
 
     def forward(self, inputs: torch.Tensor, prompts: torch.Tensor = DUMMY):
-        assert inputs.ndim == 3
+        assert inputs.ndim == 3, "inputs must be a tensor of shape [batch_size, seq_length, hidden_size]"
         assert inputs.shape[1] <= 2048, "The sequence length is capped at 2048 tokens in this version"
         outputs = _RemoteSequentialAutogradFunction.apply(inputs, prompts, self.sequence_manager)
         return outputs

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -54,7 +54,7 @@ class RemoteSequential(nn.Module):
 
     def forward(self, inputs: torch.Tensor, prompts: torch.Tensor = DUMMY):
         assert inputs.ndim == 3
-        assert inputs.shape[1] < 2048, "The sequence length is capped at 2047 tokens in this version"
+        assert inputs.shape[1] <= 2048, "The sequence length is capped at 2048 tokens in this version"
         outputs = _RemoteSequentialAutogradFunction.apply(inputs, prompts, self.sequence_manager)
         return outputs
 

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -53,6 +53,8 @@ class RemoteSequential(nn.Module):
             self.is_subsequence = self.sequence_manager.sequence_info.block_uids != block_uids
 
     def forward(self, inputs: torch.Tensor, prompts: torch.Tensor = DUMMY):
+        assert inputs.ndim == 3
+        assert inputs.shape[1] < 2048, "The sequence length is capped at 2047 tokens in this version"
         outputs = _RemoteSequentialAutogradFunction.apply(inputs, prompts, self.sequence_manager)
         return outputs
 


### PR DESCRIPTION
### Sequence length limits (fixed)
By default, sending over 2048 tokens to the model results in infinite retries (because servers reject this request). The new version will check for inputs to be within 2048 tokens.


### Integrity hiccups (investigating)

<details> <summary>Initialized the client-side model and caught this </summary>

```python
import torch
from transformers import BloomTokenizerFast
from petals.client import DistributedBloomForCausalLM
assert 'model' not in globals(), "please restart the kernel"

MODEL_NAME = "bigscience/bloom-petals"
tokenizer = BloomTokenizerFast.from_pretrained(MODEL_NAME, padding_side='right')
model = DistributedBloomForCausalLM.from_pretrained(MODEL_NAME, tuning_mode='ptune').cuda()
```

 </details>


```
WARN:/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py:Could not find route through the model: no servers holding blocks [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 16, 22, 25, 31, 33, 34, 36, 38, 41, 42, 45, 46, 48, 49, 50, 51, 52, 54, 55, 56, 57, 58, 59, 60, 61, 62, 64, 65, 66, 67, 68] (retry in 0 sec)
Dec 03 05:17:16.425 [WARN] [/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py._update:156] Could not find route through the model: no servers holding blocks [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 16, 22, 25, 31, 33, 34, 36, 38, 41, 42, 45, 46, 48, 49, 50, 51, 52, 54, 55, 56, 57, 58, 59, 60, 61, 62, 64, 65, 66, 67, 68] (retry in 0 sec)
WARN:/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py:Could not find route through the model: no servers holding blocks [0, 5, 13, 31, 41] (retry in 1 sec)
Dec 03 05:18:17.488 [WARN] [/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py._update:156] Could not find route through the model: no servers holding blocks [0, 5, 13, 31, 41] (retry in 1 sec)
WARN:/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py:Could not find route through the model: no servers holding blocks [13, 31, 41] (retry in 2 sec)
Dec 03 05:19:16.941 [WARN] [/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py._update:156] Could not find route through the model: no servers holding blocks [13, 31, 41] (retry in 2 sec)
WARN:/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py:Could not find route through the model: no servers holding blocks [13, 31, 41] (retry in 4 sec)
Dec 03 05:20:19.540 [WARN] [/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py._update:156] Could not find route through the model: no servers holding blocks [13, 31, 41] (retry in 4 sec)
```

The problem resolved itself after 3 minutes.

Hypothesis A: i think i had a faulty colab node. Generation also fluctuates sometimes. And then works fine.
Hypothesis B: maybe i temporarily slowed the network down due to retry loops?

### Weird dial backoffs (investigating)

WARN:/usr/local/lib/python3.8/dist-packages/petals/client/sequential_autograd.py:Caught exception when running forward from block 0 (retry in 0 sec): P2PDaemonError('failed to dial 12D3KooWMX9G4R8YFGETmAEPDdMhGnXdLFzxpuJteMjrsqC6yzKK:\n  * [/ip6/::1/tcp/33787] dial backoff\n  * [/ip4/127.0.0.1/tcp/46185] dial backoff\n  * [/ip4/10.0.0.4/tcp/46185] dial backoff\n  * [/ip4/20.172.214.200/tcp/2048] dial backoff')
Dec 03 04:28:51.705 [WARN] [/usr/local/lib/python3.8/dist-packages/petals/client/sequential_autograd.py.sequential_forward:97] Caught exception when running forward from block 0 (retry in 0 sec): P2PDaemonError('failed to dial 12D3KooWMX9G4R8YFGETmAEPDdMhGnXdLFzxpuJteMjrsqC6yzKK:\n  * [/ip6/::1/tcp/33787] dial backoff\n  * [/ip4/127.0.0.1/tcp/46185] dial backoff\n  * [/ip4/10.0.0.4/tcp/46185] dial backoff\n  * [/ip4/20.172.214.200/tcp/2048] dial backoff')
WARN:/usr/local/lib/python3.8/dist-packages/petals/client/sequential_autograd.py:Caught exception when running forward from block 0 (retry in 1 sec): P2PDaemonError('failed to dial 12D3KooWMX9G4R8YFGETmAEPDdMhGnXdLFzxpuJteMjrsqC6yzKK:\n  * [/ip4/127.0.0.1/tcp/46185] dial backoff\n  * [/ip4/10.0.0.4/tcp/46185] dial backoff\n  * [/ip6/::1/tcp/33787] dial backoff\n  * [/ip4/20.172.214.200/tcp/2048] dial backoff')
Dec 03 04:28:55.276 [WARN] [/usr/local/lib/python3.8/dist-packages/petals/client/sequential_autograd.py.sequential_forward:97] Caught exception when running forward from block 0 (retry in 1 sec): P2PDaemonError('failed to dial 12D3KooWMX9G4R8YFGETmAEPDdMhGnXdLFzxpuJteMjrsqC6yzKK:\n  * [/ip4/127.0.0.1/tcp/46185] dial backoff\n  * [/ip4/10.0.0.4/tcp/46185] dial backoff\n  * [/ip6/::1/tcp/33787] dial backoff\n  * [/ip4/20.172.214.200/tcp/2048] dial backoff')


