### PR TITLE
Clear trigger before engaging in update

### DIFF
--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -279,8 +279,8 @@ class _SequenceManagerUpdateThread(threading.Thread):
                 break
 
             try:
-                update_manager()
                 self.trigger.clear()
+                update_manager()
             except Exception as e:
                 logger.exception(e)
             finally:


### PR DESCRIPTION
Previously, the following edge case would be possible:

- seqmanager.thread has just finished updating and is __about__ to clear trigger - but not yet
- at the same time, user calls another seqmanager.update(wait=True)
- seqmanager.thread clears the trigger immediately -- since it was just about to do that
- user's update never finishes because it was not properly triggered
