### PR TITLE
Fix "could not unlink the shared memory file" during rebalancing

### DIFF
--- a/src/petals/server/task_pool.py
+++ b/src/petals/server/task_pool.py
@@ -105,6 +105,8 @@ class PrioritizedTaskPool(TaskPoolBase):
     def submit_task(self, *args: torch.Tensor, priority: float = 0.0) -> MPFuture:
         """Add task to this pool's queue, return Future for its output"""
         future = MPFuture()
+        # Remove shmem from MPFuture. This disables the .cancel() feature but
+        # saves the server from "could not unlink the shared memory file" crashes during rebalancing
         future._shared_state_code = torch.tensor([ALL_STATES.index(PENDING)], dtype=torch.uint8)
 
         task = Task(priority, time.monotonic(), future, args)


### PR DESCRIPTION
This PR struggles to address this crash during rebalancing:

```
terminate called after throwing an instance of 'c10::Error'
  what():  could not unlink the shared memory file /torch_4908_368690559_8693
Exception raised from close at ../aten/src/ATen/MapAllocator.cpp:514 (most recent call first):
frame #0: c10::Error::Error(c10::SourceLocation, std::string) + 0x3e (0x7ff74c4c786e in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #1: c10::detail::torchCheckFail(char const*, char const*, unsigned int, std::string const&) + 0x5c (0x7ff74c4923a8 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #2: at::RefcountedMapAllocator::close() + 0xd1 (0x7ff66a38cc11 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libtorch_cpu.so)
frame #3: THManagedMapAllocator::close() + 0x4b (0x7ff74c681c3b in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libshm.so)
frame #4: <unknown function> + 0x4cc3 (0x7ff74c681cc3 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libshm.so)
frame #5: <unknown function> + 0x4dc508 (0x7ff73b2fd508 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libtorch_python.so)
frame #6: <unknown function> + 0x40825 (0x7ff74c4af825 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #7: c10::TensorImpl::~TensorImpl() + 0x2ca (0x7ff74c4a8bba in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #8: c10::TensorImpl::~TensorImpl() + 0x9 (0x7ff74c4a8d09 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libc10.so)
frame #9: <unknown function> + 0x7298d8 (0x7ff73b54a8d8 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libtorch_python.so)
frame #10: THPVariable_subclass_dealloc(_object*) + 0x2d5 (0x7ff73b54abf5 in /home/borzunov/.local/lib/python3.8/site-packages/torch/lib/libtorch_python.so)
frame #11: python() [0x5ce483]
frame #12: python() [0x5d400c]
frame #13: python() [0x5a929d]
<omitting python frames>
frame #16: python() [0x50bc2c]
frame #24: python() [0x50bc2c]
frame #26: python() [0x658dfc]
frame #27: python() [0x679e18]
frame #28: <unknown function> + 0x8609 (0x7ff752509609 in /lib/x86_64-linux-gnu/libpthread.so.0)
frame #29: clone + 0x43 (0x7ff752643133 in /lib/x86_64-linux-gnu/libc.so.6)
```