### PR TITLE
Fix waiting until free memory is available

### DIFF
--- a/src/petals/server/cache.py
+++ b/src/petals/server/cache.py
@@ -77,7 +77,7 @@ class MemoryCache:
             async with hivemind.utils.enter_asynchronously(self._lock_acquire_memory):
                 if self.current_size_bytes + allocated_size_bytes > self.max_size_bytes:
                     await loop.run_in_executor(
-                        None, self._wait_until_available, allocated_size_bytes, timeout=self.alloc_timeout
+                        None, self._wait_until_available, allocated_size_bytes, self.alloc_timeout
                     )
                 async with hivemind.utils.enter_asynchronously(self._lock_metadata):
                     allocated_handle = int(self.handle_counter)


### PR DESCRIPTION
Fixes a simple bug that appears since `loop.run_in_executor()` can't accept kwargs:

```python
Dec 06 14:54:30.458 [WARN] [hivemind.p2p.p2p_daemon._process_stream:432] Handler failed with the exception:
Traceback (most recent call last):
  File "/home/jheuristic/anaconda3/envs/bloom-demo/lib/python3.8/site-packages/hivemind/p2p/p2p_daemon.py", line 423, in _process_stream
    async for response in handler(_read_stream(), context):
  File "/home/jheuristic/anaconda3/envs/bloom-demo/lib/python3.8/site-packages/hivemind/p2p/p2p_daemon.py", line 521, in _stream_handler
    async for item in output:
  File "/storage/hdd1/jheuristic/exp/decentralized/borzunov/bloom-demo/src/petals/server/handler.py", line 118, in rpc_inference
    async with self._allocate_caches(requested_backends, batch_size, max_length) as cache_handles:
  File "/home/jheuristic/anaconda3/envs/bloom-demo/lib/python3.8/contextlib.py", line 171, in __aenter__
    return await self.gen.__anext__()
  File "/storage/hdd1/jheuristic/exp/decentralized/borzunov/bloom-demo/src/petals/server/handler.py", line 350, in _allocate_caches
    handles.append(await stack.enter_async_context(backend.memory_cache.allocate_cache(descr)))
  File "/home/jheuristic/anaconda3/envs/bloom-demo/lib/python3.8/contextlib.py", line 568, in enter_async_context
    result = await _cm_type.__aenter__(cm)
  File "/home/jheuristic/anaconda3/envs/bloom-demo/lib/python3.8/contextlib.py", line 171, in __aenter__
    return await self.gen.__anext__()
  File "/storage/hdd1/jheuristic/exp/decentralized/borzunov/bloom-demo/src/petals/server/cache.py", line 79, in allocate_cache
    await loop.run_in_executor(
  File "uvloop/loop.pyx", line 2688, in uvloop.loop.Loop.run_in_executor
TypeError: run_in_executor() got an unexpected keyword argument 'timeout'
```