### PR TITLE
Show route on client

### DIFF
--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -117,6 +117,8 @@ class RemoteSequenceManager:
             span_sequence.append(RemoteSpanInfo(start=current_index, end=chosen_span.end, peer_id=chosen_span.peer_id))
             current_index = chosen_span.end
 
+        route_repr = " => ".join([f"{span.start}:{span.end} via …{str(span.peer_id)[-6:]}" for span in span_sequence])
+        logger.info(f"Route found: {route_repr}")
         return span_sequence
 
     def __getitem__(self, ix: Union[int, slice]) -> RemoteSequenceManager:


### PR DESCRIPTION
Works like this:

```
Dec 08 16:12:28.982 [INFO] Route found: 0:8 via …DQyuoL => 8:15 via …hNrZF5 => 15:30 via …iRUz6M => 30:45 via …i9CA9T => 45:70 via …zbDrjo
Dec 08 16:12:35.460 [INFO] How is "red" translated to French? Is
Dec 08 16:12:37.006 [INFO] How is "red" translated to French? Is it
Dec 08 16:12:38.558 [INFO] How is "red" translated to French? Is it "
Dec 08 16:12:40.143 [INFO] How is "red" translated to French? Is it "ro
Dec 08 16:12:41.700 [INFO] How is "red" translated to French? Is it "rouge
Dec 08 16:12:43.222 [INFO] How is "red" translated to French? Is it "rouge"
```