### PR TITLE
Improve block size calculations

### DIFF
--- a/src/petals/server/block_utils.py
+++ b/src/petals/server/block_utils.py
@@ -1,0 +1,48 @@
+from typing import Optional, Union
+
+import torch
+from accelerate import init_empty_weights
+
+from petals.bloom import BloomBlock, BloomConfig
+
+
+def resolve_block_dtype(config: BloomConfig, dtype: Union[str, torch.dtype]) -> Union[str, torch.dtype]:
+    """If dtype is "auto", resolves it using BloomConfig. Returns `dtype` intact otherwise."""
+
+    if dtype == "auto" or dtype is None:
+        dtype = config.torch_dtype
+        if dtype == "auto" or dtype is None:
+            dtype = torch.float32
+    return dtype
+
+
+def get_block_size(
+    config: BloomConfig,
+    location: str,
+    *,
+    dtype: Optional[Union[str, torch.dtype]] = None,
+    load_in_8bit: Optional[bool] = None,
+    layer_index: int = 0,
+    eps: float = 0.01,  # eps accounts for ~1% of metainfo for tensor descriptions, quantization tables, etc.
+) -> int:
+    if location == "memory":
+        assert (
+            dtype is not None and load_in_8bit is not None
+        ), 'get_block_size(..., location="memory") requires to specify dtype and load_in_8bit for calculations'
+
+    with init_empty_weights():
+        block = BloomBlock(config, layer_index)
+        n_params = sum(param.numel() for param in block.parameters())
+
+    if location == "memory" and load_in_8bit:
+        # Note: We may need a larger eps here for models of size < 1B
+        return n_params * (1 + eps)
+
+    if location == "memory":
+        dtype = resolve_block_dtype(config, dtype)
+    elif location == "disk":
+        dtype = resolve_block_dtype(config, "auto")
+    else:
+        raise ValueError('get_block_size() expects location to be "memory" or "disk"')
+
+    return round(n_params * torch.finfo(dtype).bits // 8 * (1 + eps))

--- a/src/petals/server/throughput.py
+++ b/src/petals/server/throughput.py
@@ -13,6 +13,7 @@ from hivemind.utils.logging import get_logger, use_hivemind_log_handler
 from petals.bloom.block import BloomBlock
 from petals.bloom.model import BloomConfig
 from petals.bloom.ops import build_alibi_tensor
+from petals.server.block_utils import resolve_block_dtype
 from petals.utils.convert_8bit import replace_8bit_linear
 from petals.utils.disk_cache import DEFAULT_CACHE_DIR
 
@@ -29,11 +30,7 @@ def get_host_throughput(
     force_eval: bool = False,
     cache_dir: Optional[str] = None,
 ) -> float:
-    # Resolve default dtypes
-    if dtype == "auto" or dtype is None:
-        dtype = config.torch_dtype
-        if dtype == "auto" or dtype is None:
-            dtype = torch.float32
+    dtype = resolve_block_dtype(config, dtype)
 
     if cache_dir is None:
         cache_dir = DEFAULT_CACHE_DIR


### PR DESCRIPTION
Now (in case of `bigscience/bloom-petals`, `load_in_8bit=True`):

- 80 GB -> 27 blocks
- 48 GB -> 16 blocks
- 40 GB -> 13 blocks
- 32 GB -> 10 blocks
- 16 GB -> 4 blocks
- 8 GB -> 2 blocks