### PR TITLE
Fix OOMs during server rebalancing

### DIFF
--- a/src/petals/server/backend.py
+++ b/src/petals/server/backend.py
@@ -85,3 +85,13 @@ class TransformerBackend(ModuleBackend):
     def get_info(self) -> Dict[str, Any]:
         """Get module parameters and stats. Used by RemoteExpert to check shapes and for DMoE orchestration."""
         return dict(super().get_info(), inference_schema=self.inference_schema)
+
+    def shutdown(self):
+        # Break the cyclic references, otherwise TransformerBackend may be not garbage-collected
+        self.forward_pool = self.backward_pool = self.inference_pool = None
+
+        # Explicitly free the GPU memory. This is not necessary at the time this code is written,
+        # but may help to avoid future issues when the module is not garbage-collected for some reasons
+        dummy = torch.tensor([])
+        for p in self.module.parameters():
+            p.data = dummy


### PR DESCRIPTION
The cause of OOMs were the cyclic references `TransformerBackend <-> PrioritizedTaskPool` that could not have been garbage collected properly:

<img width="751" alt="Screenshot 2022-12-13 at 00 31 30" src="https://user-images.githubusercontent.com/8748943/207150551-902fb289-e54a-497f-8047-2a7b70faebd2.png">

Still, I've added explicit tensor removal just in case.