### PR TITLE
Fix arguments in remove_old_models.py

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")
           python -c "from huggingface_hub import delete_repo; delete_repo(token='$BLOOM_TESTING_WRITE_TOKEN', \
-          name='test-bloomd-560m-$HF_TAG', organization='bloom-testing')" || true
+          repo_id='bloom-testing/test-bloomd-560m-$HF_TAG')" || true
       - name: Convert model and push to hub
         run: |
           export HF_TAG=$(python -c "import os; print(os.environ.get('GITHUB_HEAD_REF') or os.environ.get('GITHUB_REF_NAME'))")

--- a/tests/scripts/remove_old_models.py
+++ b/tests/scripts/remove_old_models.py
@@ -22,4 +22,4 @@ if __name__ == "__main__":
             if args.dry_run:
                 print(f"{model.modelId} can be deleted")
             else:
-                delete_repo(token=args.use_auth_token, name=model.modelId, organization=args.author)
+                delete_repo(repo_id=f"{args.author}/{model.modelId}", token=args.use_auth_token)

--- a/tests/scripts/remove_old_models.py
+++ b/tests/scripts/remove_old_models.py
@@ -22,4 +22,4 @@ if __name__ == "__main__":
             if args.dry_run:
                 print(f"{model.modelId} can be deleted")
             else:
-                delete_repo(repo_id=f"{args.author}/{model.modelId}", token=args.use_auth_token)
+                delete_repo(repo_id=model.modelId, token=args.use_auth_token)


### PR DESCRIPTION
New versions of huggingface-hub [do not have](https://huggingface.co/docs/huggingface_hub/v0.11.0/en/package_reference/hf_api#huggingface_hub.HfApi.delete_repo) `name` as an argument for `delete_repo`, thus we need to replace it with `repo_id`