### PR TITLE
Check reachability automatically and give advice how to fix it

### DIFF
--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -30,13 +30,14 @@ def main():
                                                                  "use the same name as in the converted model.")
 
     parser.add_argument('--port', type=int, required=False,
-                        help='Port this server will use. '
-                             'This is a simplified way to set the --host_maddrs and --announce_maddrs options (see below).'
-                             'Default: a random port')
+                        help='Port this server listens to. '
+                             'This is a simplified way to set the --host_maddrs and --announce_maddrs options (see below) '
+                             'that sets the port across all interfaces (IPv4, IPv6) and protocols (TCP, etc.) '
+                             'to the same number. Default: a random free port is chosen for each interface and protocol')
     parser.add_argument('--public_ip', type=str, required=False,
                         help='Your public IPv4 address, which is visible from the Internet. '
                              'This is a simplified way to set the --announce_maddrs option (see below).'
-                             'Default: IPv4/IPv6 addresses of your network interfaces')
+                             'Default: server announces IPv4/IPv6 addresses of your network interfaces')
 
     parser.add_argument('--host_maddrs', nargs='+', required=False,
                         help='Multiaddrs to listen for external connections from other peers')

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -145,9 +145,11 @@ def main():
     args["converted_model_name_or_path"] = args.pop("model") or args["converted_model_name_or_path"]
 
     host_maddrs = args.pop("host_maddrs")
-    port = args.pop("port", 0)  # Default: a random port will be chosen unless --host_maddrs are specified
+    port = args.pop("port")
     if port is not None:
         assert host_maddrs is None, "You can't use --port and --host_maddrs at the same time"
+    else:
+        port = 0
     if host_maddrs is None:
         host_maddrs = [f"/ip4/0.0.0.0/tcp/{port}", f"/ip6/::/tcp/{port}"]
 

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -187,7 +187,14 @@ def main():
     if load_in_8bit is not None:
         args["load_in_8bit"] = load_in_8bit.lower() in ["true", "1"]
 
-    server = Server(**args, host_maddrs=host_maddrs, announce_maddrs=announce_maddrs, compression=compression, max_disk_space=max_disk_space, attn_cache_size=attn_cache_size)
+    server = Server(
+        **args,
+        host_maddrs=host_maddrs,
+        announce_maddrs=announce_maddrs,
+        compression=compression,
+        max_disk_space=max_disk_space,
+        attn_cache_size=attn_cache_size,
+    )
     try:
         server.run()
     except KeyboardInterrupt:

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -188,7 +188,7 @@ class Server:
 
     def _check_reachability(self):
         try:
-            r = requests.get(f"http://health.petals.ml/api/v1/is_reachable/{self.dht.peer_id}")
+            r = requests.get(f"http://health.petals.ml/api/v1/is_reachable/{self.dht.peer_id}", timeout=10)
             r.raise_for_status()
             response = r.json()
         except Exception as e:

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -196,13 +196,14 @@ class Server:
             return
 
         if not response["success"]:
+            # This happens only if health.petals.ml is up and explicitly told us that we are unreachable
             raise RuntimeError(
                 f"Server is not reachable from the Internet:\n\n"
                 f"{response['message']}\n\n"
                 f"You need to fix your port forwarding and/or firewall settings. How to do that:\n\n"
                 f"    1. Choose a specific port for the Petals server, for example, 31337.\n"
                 f"    2. Ensure that this port is accessible from the Internet and not blocked by your firewall.\n"
-                f"    3. Add this to the command to explicitly announce your IP address and port to other peers:\n"
+                f"    3. Add these arguments to explicitly announce your IP address and port to other peers:\n"
                 f"        python -m petals.cli.run_server ... --public_ip {response['your_ip']} --port 31337\n"
                 f"    4. If it does not help, ask for help in our Discord: https://discord.gg/Wuk8BnrEPH\n"
             )


### PR DESCRIPTION
1. If we connect to the **public swarm**, the server now **automatically checks its DHT's reachability** from the outside world using API at http://health.petals.ml This is important to disallow unreachable servers to proceed (they create issues for the clients, such as repetitive retries).

    If http://health.petals.ml is down, the server proceeds without the check (so we don't depend on it). However, if health.petals.ml is up and explicitly tells us that we are unrechable, the server shows the following error (with the public IP fetched automatically):

    ```
    RuntimeError: Server is not reachable from the Internet:
    
    Failed to connect in 5 sec. Firewall may be blocking connections
    
    You need to fix your port forwarding and/or firewall settings. How to do that:
    
        1. Choose a specific port for the Petals server, for example, 31337.
        2. Ensure that this port is accessible from the Internet and not blocked by your firewall.
        3. Add these arguments to explicitly announce your IP address and port to other peers:
            python -m petals.cli.run_server ... --public_ip 93.106.106.33 --port 31337
        4. If it does not help, ask for help in our Discord: https://discord.gg/Wuk8BnrEPH
    ```
    The check may be disabled with the `--skip_reachability_check` option (though I can't imagine cases where someone needs to use it).

2. Added `--port` and `--public_ip` as **simplified convenience options** for users not familiar with `--host_maddrs` and `--announce_maddrs`.

    This is **useful for us as well**, since once we add QUIC, you'd need to write a crazy long `--announce_maddrs` (with 4 copies of your public IP for IPv4/TCP, IPv4/QUIC, IPv6/TCP, IPv6/QUIC) without having the simplified `--public_ip` option.