### PR TITLE
Hot fix: Increase hivemind.P2P's startup_timeout for Colab, remove absent initial peer

### DIFF
--- a/src/petals/constants.py
+++ b/src/petals/constants.py
@@ -3,6 +3,4 @@ PUBLIC_INITIAL_PEERS = [
     "/dns6/bootstrap1.petals.ml/tcp/31337/p2p/QmedTaZXmULqwspJXz44SsPZyTNKxhnnFvYRajfH7MGhCY",
     "/dns/bootstrap2.petals.ml/tcp/31338/p2p/QmQGTqmM7NKjV6ggU1ZCap8zWiyKR89RViDXiqehSiCpY5",
     "/dns6/bootstrap2.petals.ml/tcp/31338/p2p/QmQGTqmM7NKjV6ggU1ZCap8zWiyKR89RViDXiqehSiCpY5",
-    "/dns/bootstrap3.petals.ml/tcp/31339/p2p/QmX82nfE57CSkNgyEC7pPMPBzjcFLLJXdHhvp1AXKVPvJD",
-    "/dns6/bootstrap3.petals.ml/tcp/31339/p2p/QmX82nfE57CSkNgyEC7pPMPBzjcFLLJXdHhvp1AXKVPvJD",
 ]


### PR DESCRIPTION
Something on Colab has changed, and today we usually get this while creating a model:

<img width="672" alt="Screenshot 2022-12-19 at 19 18 57" src="https://user-images.githubusercontent.com/8748943/208459022-864d1646-4828-4e0b-9bb7-1c009c80889b.png">

This PR increases the startup timeout and removes the absent 3rd initial peer to speed up the startup a little.

The reason of the failure also could be a strange state of the 2nd bootstrap peer. I'm investigating it.