### PR TITLE
Allow to disable chunked forward

### DIFF
--- a/src/petals/bloom/modeling_utils.py
+++ b/src/petals/bloom/modeling_utils.py
@@ -45,8 +45,10 @@ class LMHead(nn.Module):
     def forward(self, hidden_states):
         word_embeddings = self.word_embeddings.weight
 
-        if self.chunk_size is not None and (
-            word_embeddings.dtype in [torch.float16, torch.bfloat16] and word_embeddings.device.type == "cpu"
+        if (
+            self.chunk_size is not None
+            and word_embeddings.dtype in [torch.float16, torch.bfloat16]
+            and word_embeddings.device.type == "cpu"
         ):
             lm_logits = self.chunked_forward(hidden_states)
         else:

--- a/src/petals/bloom/modeling_utils.py
+++ b/src/petals/bloom/modeling_utils.py
@@ -45,8 +45,9 @@ class LMHead(nn.Module):
     def forward(self, hidden_states):
         word_embeddings = self.word_embeddings.weight
 
-        # We use 'chunked_forward' only when embeddings are in half-precision on CPU.
-        if word_embeddings.dtype in [torch.float16, torch.bfloat16] and word_embeddings.device.type == "cpu":
+        if self.chunk_size is not None and (
+            word_embeddings.dtype in [torch.float16, torch.bfloat16] and word_embeddings.device.type == "cpu"
+        ):
             lm_logits = self.chunked_forward(hidden_states)
         else:
             # Switch dtype in case word_embeddings are fp16/bf16

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -34,8 +34,8 @@ class DistributedBloomConfig(BloomConfig):
     dht_prefix: str  # a prefix for all dht keys that correspond to this model (usually equal to model name)
     daemon_startup_timeout: int = 30
     dht: Optional[hivemind.DHT] = None  # a running DHT instance, e.g. when using the same DHT for multiple models
-    # a chunk size for a LM head for efficient half-precision on CPU. Default: disabled
-    chunk_size_for_efficient_fp16_on_cpu: Optional[int] = None
+    chunk_size_for_efficient_fp16_on_cpu: Optional[int] = 10000
+    # Chunk size for efficient half-precision on CPU in the LM head. Set to None if your CPU works fast with bfloat16.
     pre_seq_len: int = 0  # a number of tokens for prompt tuning.
     tuning_mode: Optional[str] = None  # One of the finetune options: [None, 'shallow_ptune', 'deep_ptune', 'adapters']
     request_timeout: int = 30  # a number of seconds for waiting result from each node

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -34,7 +34,8 @@ class DistributedBloomConfig(BloomConfig):
     dht_prefix: str  # a prefix for all dht keys that correspond to this model (usually equal to model name)
     daemon_startup_timeout: int = 30
     dht: Optional[hivemind.DHT] = None  # a running DHT instance, e.g. when using the same DHT for multiple models
-    chunk_size_for_efficient_fp16_on_cpu: int = 10000  # a chunk size for a LM head for efficient half-precision on CPU
+    # a chunk size for a LM head for efficient half-precision on CPU. Default: disabled
+    chunk_size_for_efficient_fp16_on_cpu: Optional[int] = None
     pre_seq_len: int = 0  # a number of tokens for prompt tuning.
     tuning_mode: Optional[str] = None  # One of the finetune options: [None, 'shallow_ptune', 'deep_ptune', 'adapters']
     request_timeout: int = 30  # a number of seconds for waiting result from each node


### PR DESCRIPTION
I've benchmarked the client, measuring the **time for computing logits**, and got the following results:

**nora, using CPU 0-4**

- CPU-only, bfloat16, chunked forward: 1.9 sec/token
- CPU-only, bfloat16, no chunked forward: 0.2 sec/token **(10x faster!)**
- CPU-only, float32: 0.2 sec/token
- GPU: 0.003 sec/token

**AMD EPYC-Rome Processor (Datacrunch CPU instance)**

- CPU-only, bfloat16, chunked forward: 2.7 sec/token
- CPU-only, bfloat16, no chunked forward: 19.6 sec/token **(7x slower!)**
- CPU-only, float32: 0.6 sec/token

Thus, it's useful to have a way to disable `chunked_forward()` on some CPU models.