### PR TITLE
hotfix: add initial peer that did not crash :)

### DIFF
--- a/src/petals/constants.py
+++ b/src/petals/constants.py
@@ -3,4 +3,5 @@ PUBLIC_INITIAL_PEERS = [
     "/dns6/bootstrap1.petals.ml/tcp/31337/p2p/QmedTaZXmULqwspJXz44SsPZyTNKxhnnFvYRajfH7MGhCY",
     "/dns/bootstrap2.petals.ml/tcp/31338/p2p/QmQGTqmM7NKjV6ggU1ZCap8zWiyKR89RViDXiqehSiCpY5",
     "/dns6/bootstrap2.petals.ml/tcp/31338/p2p/QmQGTqmM7NKjV6ggU1ZCap8zWiyKR89RViDXiqehSiCpY5",
+    "/ip4/193.106.95.184/tcp/46419/p2p/12D3KooWHqdGgDZZRCRDKqiikB1ofC3xLnV3oUynepUfDjNh5g9X",
 ]


### PR DESCRIPTION
It appears we killed bootstrap.petals.ml and bootstrap2.petals.ml for some arbitrary reason. This PR lets everyone access the swarm (again) and contribute to it until we revive those two peers.