### PR TITLE
Remove protobuf from requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,6 @@ install_requires =
     accelerate==0.15.0
     huggingface-hub==0.11.1
     transformers==4.25.1
-    protobuf>=3.20.3,<4.0dev
     speedtest-cli==2.1.3
     hivemind==1.1.3
     tensor_parallel==1.0.23


### PR DESCRIPTION
A correct protobuf version should be already installed by hivemind.

This also resolves version conflict on Colab, where protobuf versions required by Petals were different from the ones required by pre-installed tensorflow and tensorboard packages.

`Co-authored-by: Max Ryabinin <mryabinin0@gmail.com>`