### PR TITLE
Support libp2p relays for NAT traversal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     huggingface-hub==0.11.1
     transformers==4.25.1
     speedtest-cli==2.1.3
-    hivemind==1.1.3
+    hivemind==1.1.5
     tensor_parallel==1.0.23
     humanfriendly
     async-timeout>=4.0.2

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -127,7 +127,10 @@ def main():
     parser.add_argument("--mean_balance_check_period", type=float, default=60,
                         help="Check the swarm's balance every N seconds (and rebalance it if necessary)")
 
+    parser.add_argument("--auto_relay", action='store_true', help="Enabling relay for NAT traversal")
+    parser.add_argument('--no-auto_relay', dest='auto_relay', action='store_false')
     parser.add_argument("--use_auth_token", action='store_true', help="auth token for from_pretrained")
+
     parser.add_argument('--load_in_8bit', type=str, default=None,
                         help="Convert the loaded transformer blocks into mixed-8bit quantized model. "
                              "Default: True if GPU is available. Use `--load_in_8bit False` to disable this")
@@ -140,7 +143,7 @@ def main():
                         help="Skip checking this server's reachability via health.petals.ml "
                              "when connecting to the public swarm. If you connect to a private swarm, "
                              "the check is skipped by default. Use this option only if you know what you are doing")
-
+    parser.set_defaults(auto_relay=True)
     # fmt:on
     args = vars(parser.parse_args())
     args.pop("config", None)
@@ -158,6 +161,8 @@ def main():
 
     announce_maddrs = args.pop("announce_maddrs")
     public_ip = args.pop("public_ip")
+    use_auto_relay = args.pop("auto_relay")
+
     if public_ip is not None:
         assert announce_maddrs is None, "You can't use --public_ip and --announce_maddrs at the same time"
         assert port != 0, "Please specify a fixed non-zero --port when you use --public_ip (e.g., --port 31337)"
@@ -197,6 +202,7 @@ def main():
         compression=compression,
         max_disk_space=max_disk_space,
         attn_cache_size=attn_cache_size,
+        use_auto_relay=use_auto_relay,
     )
     try:
         server.run()

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -107,6 +107,8 @@ class DistributedBloomModel(_LowCPUMemoryMixin, BloomModel):
                 num_workers=n_layer,
                 startup_timeout=config.daemon_startup_timeout,
                 start=True,
+                use_relay=True,
+                use_auto_relay=True,
             )
         )
         assert isinstance(dht, hivemind.DHT) and dht.is_alive(), "dht must be a running hivemind.DHT instance"

--- a/src/petals/server/reachability.py
+++ b/src/petals/server/reachability.py
@@ -1,3 +1,4 @@
+import math
 import time
 
 import requests

--- a/src/petals/server/reachability.py
+++ b/src/petals/server/reachability.py
@@ -1,0 +1,37 @@
+import time
+
+import requests
+from hivemind.utils.logging import get_logger
+
+logger = get_logger(__file__)
+
+
+def check_reachability(peer_id, wait_time: float = 600, retry_delay: float = 15) -> None:
+    for attempt_no in range(math.floor(wait_time / retry_delay) + 1):
+        try:
+            r = requests.get(f"http://health.petals.ml/api/v1/is_reachable/{peer_id}", timeout=10)
+            r.raise_for_status()
+            response = r.json()
+
+            if response["success"]:
+                logger.info("Server is reachable from the Internet. It will appear at http://health.petals.ml soon")
+                return
+
+            if attempt_no == 0:
+                # If health.petals.ml didn't manage to connect right away, we need to wait for libp2p to set up relays
+                logger.info("Detected a NAT or a firewall, connecting to libp2p relays. This takes a few minutes")
+            time.sleep(retry_delay)
+        except Exception as e:
+            logger.warning(f"Skipping reachability check because health.petals.ml is down: {repr(e)}")
+            return
+
+    raise RuntimeError(
+        f"Server has not become reachable from the Internet:\n\n"
+        f"{response['message']}\n\n"
+        f"You need to fix your port forwarding and/or firewall settings. How to do that:\n\n"
+        f"    1. Choose a specific port for the Petals server, for example, 31337.\n"
+        f"    2. Ensure that this port is accessible from the Internet and not blocked by your firewall.\n"
+        f"    3. Add these arguments to explicitly announce your IP address and port to other peers:\n"
+        f"        python -m petals.cli.run_server ... --public_ip {response['your_ip']} --port 31337\n"
+        f"    4. If it does not help, ask for help in our Discord: https://discord.gg/Wuk8BnrEPH\n"
+    )

--- a/src/petals/server/reachability.py
+++ b/src/petals/server/reachability.py
@@ -6,7 +6,7 @@ from hivemind.utils.logging import get_logger
 logger = get_logger(__file__)
 
 
-def check_reachability(peer_id, wait_time: float = 600, retry_delay: float = 15) -> None:
+def check_reachability(peer_id, wait_time: float = 7 * 60, retry_delay: float = 15) -> None:
     for attempt_no in range(math.floor(wait_time / retry_delay) + 1):
         try:
             r = requests.get(f"http://health.petals.ml/api/v1/is_reachable/{peer_id}", timeout=10)
@@ -18,7 +18,8 @@ def check_reachability(peer_id, wait_time: float = 600, retry_delay: float = 15)
                 return
 
             if attempt_no == 0:
-                # If health.petals.ml didn't manage to connect right away, we need to wait for libp2p to set up relays
+                # Usually, libp2p manages to set up relays before we finish loading blocks.
+                # In other cases, we may need to wait for up to `wait_time` seconds before it's done.
                 logger.info("Detected a NAT or a firewall, connecting to libp2p relays. This takes a few minutes")
             time.sleep(retry_delay)
         except Exception as e:

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -78,6 +78,8 @@ class Server:
         load_in_8bit: Optional[bool] = None,
         tensor_parallel_devices: Optional[Sequence[torch.device]] = None,
         skip_reachability_check: bool = False,
+        use_relay: bool = True,
+        use_auto_relay: bool = True,
         **kwargs,
     ):
         """Create a server with one or more bloom blocks. See run_server.py for documentation."""
@@ -117,7 +119,8 @@ class Server:
         )
         self.module_uids = [f"{self.prefix}.{block_index}" for block_index in range(self.block_config.n_layer)]
 
-        self.dht = DHT(initial_peers=initial_peers, start=True, num_workers=self.block_config.n_layer, **kwargs)
+        self.dht = DHT(initial_peers=initial_peers, start=True, num_workers=self.block_config.n_layer,
+                       use_relay=use_relay, use_auto_relay=use_auto_relay, **kwargs)
         visible_maddrs_str = [str(a) for a in self.dht.get_visible_maddrs()]
         if initial_peers == PUBLIC_INITIAL_PEERS:
             logger.info(f"Connecting to the public swarm, peer_id = {self.dht.peer_id}")

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -240,7 +240,9 @@ class Server:
         assert (
             self.converted_model_name_or_path == "bigscience/bloom-petals"
         ), "If you use a model other than bigscience/bloom-petals, please specify --num_blocks manually"
-        assert self.device.type == "cuda", "If you run a non-GPU server, please specify --num_blocks manually"
+        assert self.device.type == "cuda", \
+            "GPU is not available. If you want to run a CPU-only server, please specify --num_blocks. " \
+            "CPU-only servers in the public swarm are discouraged since they are much slower"
         num_devices = len(self.tensor_parallel_devices) if self.tensor_parallel_devices else 1
 
         if num_devices > 1:

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -119,8 +119,14 @@ class Server:
         )
         self.module_uids = [f"{self.prefix}.{block_index}" for block_index in range(self.block_config.n_layer)]
 
-        self.dht = DHT(initial_peers=initial_peers, start=True, num_workers=self.block_config.n_layer,
-                       use_relay=use_relay, use_auto_relay=use_auto_relay, **kwargs)
+        self.dht = DHT(
+            initial_peers=initial_peers,
+            start=True,
+            num_workers=self.block_config.n_layer,
+            use_relay=use_relay,
+            use_auto_relay=use_auto_relay,
+            **kwargs,
+        )
         visible_maddrs_str = [str(a) for a in self.dht.get_visible_maddrs()]
         if initial_peers == PUBLIC_INITIAL_PEERS:
             logger.info(f"Connecting to the public swarm, peer_id = {self.dht.peer_id}")

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -215,10 +215,7 @@ class Server:
                 response = r.json()
 
                 if response["success"]:
-                    logger.info(
-                        f"Server is reachable from the Internet. "
-                        f"It will appear at http://health.petals.ml soon, peer_id = {self.dht.peer_id}"
-                    )
+                    logger.info("Server is reachable from the Internet. It will appear at http://health.petals.ml soon")
                     return
 
                 if i < n_retries - 1:


### PR DESCRIPTION
- Added relay options to servers
- Enabled relay options by default
- Changed hivemind version to 1.1.5
- Moved reachability check to be performed after blocks are loaded