### PR TITLE
Report server version and dht.client_mode in rpc_info(), check for updates on startup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     humanfriendly
     async-timeout>=4.0.2
     cpufeature>=0.2.0
+    packaging>=23.0
 
 [options.extras_require]
 dev =

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -8,6 +8,7 @@ from humanfriendly import parse_size
 
 from petals.constants import PUBLIC_INITIAL_PEERS
 from petals.server.server import Server
+from petals.utils.version import validate_version
 
 logger = get_logger(__file__)
 
@@ -192,6 +193,8 @@ def main():
     load_in_8bit = args.pop("load_in_8bit")
     if load_in_8bit is not None:
         args["load_in_8bit"] = load_in_8bit.lower() in ["true", "1"]
+
+    validate_version()
 
     server = Server(
         **args,

--- a/src/petals/server/handler.py
+++ b/src/petals/server/handler.py
@@ -394,10 +394,9 @@ class TransformerConnectionHandler(ConnectionHandler):
 
         if request.uid:
             block_info = self.module_backends[request.uid].get_info()
-            if set(result.keys()) & set(block_info.keys()):
-                raise RuntimeError(
-                    f"The block's rpc_info has keys reserved for the server's rpc_info: {sorted(block_info.keys())}"
-                )
+            common_keys = set(result.keys()) & set(block_info.keys())
+            if common_keys:
+                raise RuntimeError(f"The block's rpc_info has keys reserved for the server's rpc_info: {common_keys}")
             result.update(block_info)
 
         return runtime_pb2.ExpertInfo(serialized_info=MSGPackSerializer.dumps(result))

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -102,7 +102,7 @@ class Server:
                 f"Cannot use model name as prefix (contains '{UID_DELIMITER}' or '{CHAIN_DELIMITER}'); "
                 f"Please specify --prefix manually when starting a server"
             )
-            logger.info(f"Automatic dht prefix: {prefix}")
+            logger.debug(f"Automatic dht prefix: {prefix}")
         self.prefix = prefix
 
         if expiration is None:

--- a/src/petals/utils/version.py
+++ b/src/petals/utils/version.py
@@ -1,0 +1,26 @@
+import requests
+from hivemind.utils.logging import TextStyle, get_logger
+from packaging.version import parse
+
+import petals
+
+logger = get_logger(__file__)
+
+
+def validate_version():
+    logger.info(f"Running {TextStyle.BOLD}Petals {petals.__version__}{TextStyle.RESET}")
+    try:
+        r = requests.get("https://pypi.python.org/pypi/petals/json")
+        r.raise_for_status()
+        response = r.json()
+
+        versions = [parse(ver) for ver in response.get("releases")]
+        latest = max(ver for ver in versions if not ver.is_prerelease)
+
+        if parse(petals.__version__) < latest:
+            logger.info(
+                f"A newer version {latest} is available. Please upgrade with: "
+                f"{TextStyle.BOLD}pip install --upgrade petals{TextStyle.RESET}"
+            )
+    except Exception as e:
+        logger.warning("Failed to fetch the latest Petals version from PyPI:", exc_info=True)


### PR DESCRIPTION
This PR:

1. Shows the current Petals version and checks for updates on startup:

<img width="806" alt="Screenshot 2023-01-13 at 06 38 46" src="https://user-images.githubusercontent.com/8748943/212224809-1892e8eb-3f92-40ed-96c5-2dd5bdbdab1f.png">

2. Reports the current version and DHT mode in `rpc_info()`, so it can be shown on http://health.petals.ml or used on clients for efficient routing:

<img width="693" alt="Screenshot 2023-01-13 at 06 42 57" src="https://user-images.githubusercontent.com/8748943/212225107-b1da0ee3-5bfb-4774-a6a2-85011eff27a7.png">

