### PR TITLE
Fix output shape when resuming generation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     humanfriendly
     async-timeout>=4.0.2
     cpufeature>=0.2.0
-    packaging>=23.0
+    packaging>=20.9
 
 [options.extras_require]
 dev =

--- a/src/petals/server/throughput.py
+++ b/src/petals/server/throughput.py
@@ -123,6 +123,8 @@ def measure_network_rps(config: BloomConfig) -> Optional[float]:
 
     bits_per_request = config.hidden_size * 16  # Clients usually send 16-bit tensors for forward/backward
     network_rps = min(network_info["download"], network_info["upload"]) / bits_per_request
+    if network_rps == 0:
+        raise ValueError("speedtest has returned network_rps == 0")
 
     logger.info(
         f"Network throughput: "


### PR DESCRIPTION
Before this PR, `model.generate()` returned one excess token when resuming generation with an existing (the last token of the previous session, `session.last_token_id`). This is an unexpected behavior not convenient for the downstream apps, so this PR changes it until it's too late.