### PR TITLE
Add `allowed_servers`, `max_retries` options to the client, improve logs

### DIFF
--- a/src/petals/client/inference_session.py
+++ b/src/petals/client/inference_session.py
@@ -307,6 +307,8 @@ class InferenceSession:
                 except Exception as e:
                     if span is not None:
                         self._sequence_manager.on_request_failure(span.peer_id)
+                    if attempt_no + 1 == self._sequence_manager.max_retries:
+                        raise
                     delay = self._sequence_manager.get_retry_delay(attempt_no)
                     logger.warning(
                         f"Caught exception when running inference from block {block_idx} "

--- a/src/petals/client/inference_session.py
+++ b/src/petals/client/inference_session.py
@@ -311,8 +311,7 @@ class InferenceSession:
                         raise
                     delay = self._sequence_manager.get_retry_delay(attempt_no)
                     logger.warning(
-                        f"Caught exception when running inference from block {block_idx} "
-                        f"(retry in {delay:.0f} sec): {repr(e)}"
+                        f"Caught exception when running inference via {span} (retry in {delay:.0f} sec): {repr(e)}"
                     )
                     maybe_log_traceback(e)
                     time.sleep(delay)

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -35,6 +35,7 @@ class DistributedBloomConfig(BloomConfig):
     daemon_startup_timeout: int = 30
     dht: Optional[hivemind.DHT] = None  # a running DHT instance, e.g. when using the same DHT for multiple models
     request_timeout: int = 30  # a number of seconds for waiting result from each node
+    max_retries: Optional[int] = None  # max number retries before the client raises an exception (default: inf)
     allowed_servers: Optional[
         Collection[Union[str, hivemind.PeerID]]
     ] = None  # if defined, send requests only to these servers
@@ -119,8 +120,6 @@ class DistributedBloomModel(_LowCPUMemoryMixin, BloomModel):
             config,
             dht,
             config.dht_prefix,
-            request_timeout=config.request_timeout,
-            allowed_servers=config.allowed_servers,
         )
 
         # Forbid accumulate grads for embeddings and layernorm

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -41,7 +41,16 @@ class RemoteSequential(nn.Module):
         block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(num_blocks))
         if sequence_manager is None:
             logger.debug(f"Creating new sequence manager for block uids: {block_uids}")
-            self.sequence_manager = RemoteSequenceManager(dht, block_uids, self.p2p, start=True, **kwargs)
+            self.sequence_manager = RemoteSequenceManager(
+                dht,
+                block_uids,
+                self.p2p,
+                request_timeout=config.request_timeout,
+                max_retries=config.max_retries,
+                allowed_servers=config.allowed_servers,
+                start=True,
+                **kwargs,
+            )
             self.is_subsequence = False
         else:
             logger.debug(f"Reusing sequence manager with {len(sequence_manager)} modules")

--- a/src/petals/client/sequential_autograd.py
+++ b/src/petals/client/sequential_autograd.py
@@ -99,8 +99,7 @@ async def sequential_forward(
                     raise
                 delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(
-                    f"Caught exception when running forward from block {block_idx} "
-                    f"(retry in {delay:.0f} sec): {repr(e)}"
+                    f"Caught exception when running forward via {span} (retry in {delay:.0f} sec): {repr(e)}"
                 )
                 maybe_log_traceback(e)
                 await asyncio.sleep(delay)
@@ -178,8 +177,7 @@ async def sequential_backward(
                     raise
                 delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(
-                    f"Caught exception when running backward between blocks {span.start}-{span.end} "
-                    f"(retry in {delay:.0f} sec): {repr(e)}"
+                    f"Caught exception when running backward via {span} (retry in {delay:.0f} sec): {repr(e)}"
                 )
                 maybe_log_traceback(e)
                 await asyncio.sleep(delay)

--- a/src/petals/client/sequential_autograd.py
+++ b/src/petals/client/sequential_autograd.py
@@ -95,6 +95,8 @@ async def sequential_forward(
             except Exception as e:
                 if span is not None:
                     sequence_manager.on_request_failure(span.peer_id)
+                if attempt_no + 1 == sequence_manager.max_retries:
+                    raise
                 delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(
                     f"Caught exception when running forward from block {block_idx} "
@@ -172,6 +174,8 @@ async def sequential_backward(
             except Exception as e:
                 if span is not None:
                     sequence_manager.on_request_failure(span.peer_id)
+                if attempt_no + 1 == sequence_manager.max_retries:
+                    raise
                 delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(
                     f"Caught exception when running backward between blocks {span.start}-{span.end} "

--- a/src/petals/server/block_selection.py
+++ b/src/petals/server/block_selection.py
@@ -16,6 +16,7 @@ class Span:
     start: int
     end: int
     throughput: float
+    state: ServerState
 
     @property
     def length(self):
@@ -43,7 +44,7 @@ def compute_spans(module_infos: List[Optional[RemoteModuleInfo]]) -> Tuple[Dict[
                 spans[peer_id].start = min(spans[peer_id].start, block)
                 spans[peer_id].end = max(spans[peer_id].start, block + 1)
             else:
-                spans[peer_id] = Span(start=block, end=block + 1, throughput=server.throughput)
+                spans[peer_id] = Span(start=block, end=block + 1, throughput=server.throughput, state=server.state)
 
             throughputs[block] += server.throughput
 


### PR DESCRIPTION
This `allowed_servers` option makes it possible to:

- Specify a list of **trusted peers** we'd like to use for inference/fine-tuning
- Specify a set of peers whose outputs we'd like to validate