### PR TITLE
Improve reachability logs

### DIFF
--- a/src/petals/server/reachability.py
+++ b/src/petals/server/reachability.py
@@ -71,7 +71,7 @@ def check_direct_reachability(max_peers: int = 5, threshold: float = 0.5, **kwar
                     if requests >= max_peers:
                         break
 
-            logger.info(f"Direct reachability: {successes}/{requests}")
+            logger.debug(f"Direct reachability: {successes}/{requests}")
             return (successes / requests) >= threshold if requests > 0 else None
         finally:
             await target_dht.shutdown()

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -122,7 +122,7 @@ class Server:
         if dht_client_mode is None:
             is_reachable = check_direct_reachability(initial_peers=initial_peers, use_relay=False, **kwargs)
             dht_client_mode = is_reachable is False  # if could not check reachability (returns None), run a full peer
-            logger.info(f"This server will run DHT in {'client' if dht_client_mode else 'full peer'} mode")
+            logger.info(f"This server is accessible {'via relays' if dht_client_mode else 'directly'}")
         self.dht = DHT(
             initial_peers=initial_peers,
             start=True,


### PR DESCRIPTION
Multiple users were confused when they saw lines `Direct reachability: 0/5` and `This server will run DHT in client mode` - they thought that the server is not accessible due to networking issues. I have updated these log lines to avoid confusion.