### PR TITLE
Show visible maddrs for public swarm too

### DIFF
--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -136,9 +136,10 @@ class Server:
 
         visible_maddrs_str = [str(a) for a in self.dht.get_visible_maddrs()]
         if initial_peers == PUBLIC_INITIAL_PEERS:
-            logger.info(f"Connecting to the public swarm, peer_id = {self.dht.peer_id}")
+            logger.info("Connecting to the public swarm")
         else:
-            logger.info(f"Running DHT node on {visible_maddrs_str}, initial peers = {initial_peers}")
+            logger.info(f"Connecting to a private swarm, initial peers: {initial_peers}")
+        logger.info(f"Running a server on {visible_maddrs_str}")
         self.should_validate_reachability = not skip_reachability_check and initial_peers == PUBLIC_INITIAL_PEERS
 
         if device is None:


### PR DESCRIPTION
Requested in Discord (see the latter):

<img width="844" alt="Screenshot 2023-02-19 at 04 13 46" src="https://user-images.githubusercontent.com/8748943/219905209-a4a026b8-1411-4037-b60e-f3f3b6a7fd06.png">

This is how it looks like:

```
Feb 19 00:07:17.324 [INFO] Connecting to the public swarm                                              
Feb 19 00:07:17.326 [INFO] Running a server on ['/ip4/1.2.3.4/tcp/36473/p2p/12D3KooWLkAYXididyPPy77oTthmrtFTVxPzwFb3sMoXmvqWQJSZ', '/ip4/127.0.0.1/tcp/36473/p2p/12D3KooWLkAYXididyPPy77oTthmrtFTVx
PzwFb3sMoXmvqWQJSZ', '/ip6/::1/tcp/39355/p2p/12D3KooWLkAYXididyPPy77oTthmrtFTVxPzwFb3sMoXmvqWQJSZ']   
```