### PR TITLE
Use get_logger(__name__) instead of get_logger(__file__)

### DIFF
--- a/src/petals/bloom/from_pretrained.py
+++ b/src/petals/bloom/from_pretrained.py
@@ -22,7 +22,7 @@ from petals.bloom.block import WrappedBloomBlock
 from petals.server.block_utils import get_block_size
 from petals.utils.disk_cache import DEFAULT_CACHE_DIR, allow_cache_reads, allow_cache_writes, free_disk_space_for
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 CLIENT_BRANCH = "main"
 BLOCK_BRANCH_PREFIX = "block_"

--- a/src/petals/bloom/modeling_utils.py
+++ b/src/petals/bloom/modeling_utils.py
@@ -13,7 +13,7 @@ from hivemind import get_logger
 from torch import nn
 from transformers import BloomConfig
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class LMHead(nn.Module):

--- a/src/petals/cli/convert_model.py
+++ b/src/petals/cli/convert_model.py
@@ -13,7 +13,7 @@ from transformers.models.bloom.modeling_bloom import BloomModel
 from petals.bloom.from_pretrained import BLOCK_BRANCH_PREFIX, CLIENT_BRANCH
 from petals.client import DistributedBloomConfig
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 DTYPE_MAP = dict(bfloat16=torch.bfloat16, float16=torch.float16, float32=torch.float32, auto="auto")
 

--- a/src/petals/cli/inference_one_block.py
+++ b/src/petals/cli/inference_one_block.py
@@ -8,7 +8,7 @@ from transformers.models.bloom.modeling_bloom import build_alibi_tensor
 
 from petals.bloom.block import BloomBlock
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 logger.warning("inference_one_block will soon be deprecated in favour of tests!")
 

--- a/src/petals/cli/run_server.py
+++ b/src/petals/cli/run_server.py
@@ -10,7 +10,7 @@ from petals.constants import PUBLIC_INITIAL_PEERS
 from petals.server.server import Server
 from petals.utils.version import validate_version
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 def main():

--- a/src/petals/client/inference_session.py
+++ b/src/petals/client/inference_session.py
@@ -25,7 +25,7 @@ from petals.data_structures import CHAIN_DELIMITER, ModuleUID, RemoteSpanInfo, R
 from petals.server.handler import TransformerConnectionHandler
 from petals.utils.misc import DUMMY, is_dummy
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class _ServerInferenceSession:

--- a/src/petals/client/remote_generation.py
+++ b/src/petals/client/remote_generation.py
@@ -15,7 +15,7 @@ from petals.utils.generation_algorithms import (
 )
 from petals.utils.generation_constraints import ABCBloomConstraint, EosConstraint
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class RemoteGenerationMixin:

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -21,7 +21,7 @@ from petals.client.remote_sequential import RemoteSequential
 from petals.constants import PUBLIC_INITIAL_PEERS
 from petals.utils.misc import DUMMY
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class DistributedBloomConfig(BloomConfig):

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -14,7 +14,7 @@ from petals.client.sequential_autograd import _RemoteSequentialAutogradFunction
 from petals.data_structures import UID_DELIMITER
 from petals.utils.misc import DUMMY
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class RemoteSequential(nn.Module):

--- a/src/petals/client/routing/sequence_info.py
+++ b/src/petals/client/routing/sequence_info.py
@@ -6,7 +6,7 @@ from hivemind import get_logger
 
 from petals.data_structures import ModuleUID, RemoteModuleInfo, RemoteSpanInfo, ServerState
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 T = TypeVar("T")

--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -23,7 +23,7 @@ from petals.client.routing.spending_policy import NoSpendingPolicy
 from petals.data_structures import ModuleUID, RemoteSpanInfo, ServerState
 from petals.server.handler import TransformerConnectionHandler
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class RemoteSequenceManager:

--- a/src/petals/client/sequential_autograd.py
+++ b/src/petals/client/sequential_autograd.py
@@ -18,7 +18,7 @@ from petals.data_structures import CHAIN_DELIMITER, RemoteSpanInfo
 from petals.server.handler import TransformerConnectionHandler
 from petals.utils.misc import DUMMY, is_dummy
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 MAX_TOKENS_IN_BATCH = 1024
 

--- a/src/petals/dht_utils.py
+++ b/src/petals/dht_utils.py
@@ -15,7 +15,7 @@ from hivemind.utils import DHTExpiration, MPFuture, get_dht_time, get_logger
 import petals.client
 from petals.data_structures import CHAIN_DELIMITER, UID_DELIMITER, ModuleUID, RemoteModuleInfo, ServerInfo, ServerState
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 def declare_active_modules(

--- a/src/petals/server/backend.py
+++ b/src/petals/server/backend.py
@@ -20,7 +20,7 @@ from petals.server.memory_cache import Handle, MemoryCache
 from petals.server.task_pool import PrioritizedTaskPool
 from petals.utils.misc import is_dummy
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class TransformerBackend(ModuleBackend):

--- a/src/petals/server/block_selection.py
+++ b/src/petals/server/block_selection.py
@@ -8,7 +8,7 @@ from petals.data_structures import RemoteModuleInfo, ServerState
 
 __all__ = ["choose_best_blocks", "should_choose_other_blocks"]
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 @dataclass

--- a/src/petals/server/handler.py
+++ b/src/petals/server/handler.py
@@ -32,7 +32,7 @@ from petals.server.task_pool import PrioritizedTaskPool
 from petals.server.task_prioritizer import DummyTaskPrioritizer, TaskPrioritizerBase
 from petals.utils.misc import DUMMY, is_dummy
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 CACHE_TOKENS_AVAILABLE = "cache_tokens_available"
 

--- a/src/petals/server/memory_cache.py
+++ b/src/petals/server/memory_cache.py
@@ -18,7 +18,7 @@ from hivemind.utils import TensorDescriptor, get_logger
 
 from petals.utils.asyncio import shield_and_wait
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 Handle = int
 

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -31,7 +31,7 @@ from petals.server.throughput import get_dtype_name, get_host_throughput
 from petals.utils.convert_block import check_device_balance, convert_block
 from petals.utils.disk_cache import DEFAULT_CACHE_DIR
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 class Server:

--- a/src/petals/server/task_pool.py
+++ b/src/petals/server/task_pool.py
@@ -12,7 +12,7 @@ from hivemind import get_logger
 from hivemind.moe.server.task_pool import TaskPoolBase
 from hivemind.utils.mpfuture import ALL_STATES, MPFuture
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 @dataclass(order=True, frozen=True)

--- a/src/petals/server/throughput.py
+++ b/src/petals/server/throughput.py
@@ -16,7 +16,7 @@ from petals.server.block_utils import resolve_block_dtype
 from petals.utils.convert_block import convert_block
 from petals.utils.disk_cache import DEFAULT_CACHE_DIR
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 try:
     import speedtest

--- a/src/petals/utils/convert_block.py
+++ b/src/petals/utils/convert_block.py
@@ -15,7 +15,7 @@ from transformers.models.bloom.modeling_bloom import BloomAttention
 from petals.bloom.block import WrappedBloomBlock
 
 use_hivemind_log_handler("in_root_logger")
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 def convert_block(

--- a/src/petals/utils/disk_cache.py
+++ b/src/petals/utils/disk_cache.py
@@ -8,7 +8,7 @@ from typing import Optional
 import huggingface_hub
 from hivemind.utils.logging import get_logger
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 DEFAULT_CACHE_DIR = os.getenv("PETALS_CACHE", Path(Path.home(), ".cache", "petals"))
 

--- a/src/petals/utils/version.py
+++ b/src/petals/utils/version.py
@@ -4,7 +4,7 @@ from packaging.version import parse
 
 import petals
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 def validate_version():

--- a/tests/test_full_model.py
+++ b/tests/test_full_model.py
@@ -8,7 +8,7 @@ from transformers.models.bloom import BloomForCausalLM
 
 from petals.client.remote_model import DistributedBloomForCausalLM
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 @pytest.mark.forked

--- a/tests/test_remote_sequential.py
+++ b/tests/test_remote_sequential.py
@@ -10,7 +10,7 @@ from petals.client import RemoteSequenceManager, RemoteSequential
 from petals.client.remote_model import DistributedBloomConfig
 from petals.data_structures import UID_DELIMITER
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 @pytest.mark.forked

--- a/tests/test_sequence_manager.py
+++ b/tests/test_sequence_manager.py
@@ -10,7 +10,7 @@ from petals.client import RemoteSequenceManager, RemoteSequential
 from petals.client.remote_model import DistributedBloomConfig
 from petals.data_structures import UID_DELIMITER
 
-logger = get_logger(__file__)
+logger = get_logger(__name__)
 
 
 @pytest.mark.forked


### PR DESCRIPTION
`get_logger()` is supposed to be called with `__name__` instead of `__file__` (as we do in hivemind), so you get nicer error messages. Once this is merged, we'll get these messages:

```
Feb 19 00:39:58.899 [WARN] [petals.server.handler._log_request:376] rpc_inference.step(blocks=7:16, remote_peer=...SsBWtX): timed out
```

Instead of this:

```
Feb 19 00:39:58.899 [WARN] [/long/full/path/exp/decentralized/borzunov/petals/src/petals/server/handler.py._log_request:376] rpc_inference.step(blocks=7:16, remote_peer=...SsBWtX): timed out
```

This should help users find the error message (now they miss it sometimes).