### PR TITLE
Improve "connect your GPU" message

### DIFF
--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -365,8 +365,8 @@ def maybe_log_traceback(exc: Exception):
 class MissingBlocksError(RuntimeError):
     def __init__(self, block_indices: Union[int, Sequence[int]]):
         super().__init__(
-            f"No servers holding blocks {block_indices} are online.\n"
-            f"You can check the public swarm's state at http://health.petals.ml\n\n"
-            f"If there are not enough servers, please consider connecting your own GPU:\n"
-            f"https://github.com/bigscience-workshop/petals#connect-your-gpu-and-increase-petals-capacity"
+            f"No servers holding blocks {block_indices} are online. "
+            f"You can check the public swarm's state at http://health.petals.ml "
+            f"If there are not enough servers, please connect your GPU: "
+            f"https://github.com/bigscience-workshop/petals#connect-your-gpu-and-increase-petals-capacity "
         )


### PR DESCRIPTION
Before this PR, the message was:

`
Feb 18 13:12:02.550 [WARN] [/usr/local/lib/python3.8/dist-packages/petals/client/routing/sequence_manager.py._update:197] Could not find route through the model: MissingBlocksError("No servers holding blocks [65, 66, 67, 68, 69] are online.\nYou can check the public swarm's state at http://health.petals.ml\n\nIf there are not enough servers, please consider connecting your own GPU:\nhttps://github.com/bigscience-workshop/petals#connect-your-gpu-and-increase-petals-capacity") (retry in 0 sec)
`

Thus, it had line breaks that made it harder to read and prevented the http://health.petals.ml link to be opened from the terminal. This PR fixes this minor issue:

`
Feb 18 13:12:02.550 [WARN] [petals.client.routing.sequence_manager._update:197] Could not find route through the model: MissingBlocksError("No servers holding blocks [65, 66, 67, 68, 69] are online. You can check the public swarm's state at http://health.petals.ml If there are not enough servers, please connect your GPU: https://github.com/bigscience-workshop/petals#connect-your-gpu-and-increase-petals-capacity ") (retry in 0 sec)
`