### PR TITLE
Use inference mode in _MergedInferenceStep

### DIFF
--- a/src/petals/server/backend.py
+++ b/src/petals/server/backend.py
@@ -159,6 +159,7 @@ class _MergedInferenceStep:
     def __init__(self, backends: Dict[ExpertUID, TransformerBackend]):
         self.backends = backends
 
+    @torch.inference_mode()
     def __call__(
         self,
         hidden_states: torch.Tensor,


### PR DESCRIPTION
This fixes a problem that
- definitely existed if inferencing with hidden_states / prompts that require grad
- likely has caused https://github.com/bigscience-workshop/petals/issues/271