### PR TITLE
Increase default request_timeout

### DIFF
--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -34,7 +34,7 @@ class DistributedBloomConfig(BloomConfig):
     dht_prefix: str  # a prefix for all dht keys that correspond to this model (usually equal to model name)
     daemon_startup_timeout: int = 30
     dht: Optional[hivemind.DHT] = None  # a running DHT instance, e.g. when using the same DHT for multiple models
-    request_timeout: int = 30  # a number of seconds for waiting result from each node
+    request_timeout: int = 60  # a number of seconds for waiting result from each node
     max_retries: Optional[int] = None  # max number retries before the client raises an exception (default: inf)
     allowed_servers: Optional[
         Collection[Union[str, hivemind.PeerID]]

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -34,7 +34,7 @@ class DistributedBloomConfig(BloomConfig):
     dht_prefix: str  # a prefix for all dht keys that correspond to this model (usually equal to model name)
     daemon_startup_timeout: int = 30
     dht: Optional[hivemind.DHT] = None  # a running DHT instance, e.g. when using the same DHT for multiple models
-    request_timeout: int = 60  # a number of seconds for waiting result from each node
+    request_timeout: int = 3 * 60  # a number of seconds for waiting result from each node
     max_retries: Optional[int] = None  # max number retries before the client raises an exception (default: inf)
     allowed_servers: Optional[
         Collection[Union[str, hivemind.PeerID]]


### PR DESCRIPTION
This PR increases `request_timeout`, since the previous default of 30 sec is not enough for many use cases.

Previously, we kept the request timeout low since we assumed that the server could freeze on dial if the target peer is behind a firewall. However, apparently, it won't freeze because libp2p has its own [dial timeout](https://github.com/libp2p/go-libp2p/blob/v0.26.0/core/network/context.go#L11).