### PR TITLE
Update dependency versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,13 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     torch>=1.12
-    bitsandbytes==0.34.0
-    accelerate==0.15.0
+    bitsandbytes==0.37.0
+    accelerate==0.16.0
     huggingface-hub==0.11.1
-    transformers==4.25.1
+    transformers==4.26.1
     speedtest-cli==2.1.3
-    hivemind==1.1.5
-    tensor_parallel==1.0.23
+    hivemind==1.1.6
+    tensor_parallel==1.0.25
     humanfriendly
     async-timeout>=4.0.2
     cpufeature>=0.2.0

--- a/src/petals/bloom/block.py
+++ b/src/petals/bloom/block.py
@@ -11,7 +11,7 @@ import transformers
 from transformers.models.bloom.modeling_bloom import BloomBlock, _expand_mask, _make_causal_mask, build_alibi_tensor
 
 if not os.getenv("PETALS_IGNORE_DEPENDENCY_VERSION"):
-    assert transformers.__version__.startswith("4.25."), "Please install transformers 4.25.1"
+    assert transformers.__version__.startswith("4.26."), "Please install transformers 4.26.1"
 
 
 class WrappedBloomBlock(BloomBlock):


### PR DESCRIPTION
## Why:
- support new GPUs (ada, hopper)
- dependency for #273 
- better bf16 communication (phase 1/2)

## Tests:
- [x] check local tests
- [x] check exact match (running a server)
- [x] check running a server with new BF16 flag
- [ ] check running a server with TP=2