### PR TITLE
Update bitsandbytes, hivemind, transformers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,13 +32,13 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     torch>=1.12
-    bitsandbytes==0.34.0
+    bitsandbytes==0.37.1
     accelerate==0.15.0
     huggingface-hub==0.11.1
     transformers==4.25.1
     speedtest-cli==2.1.3
-    hivemind==1.1.5
-    tensor_parallel==1.0.23
+    hivemind==1.1.6
+    tensor_parallel==1.1.0
     humanfriendly
     async-timeout>=4.0.2
     cpufeature>=0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     transformers==4.25.1
     speedtest-cli==2.1.3
     hivemind==1.1.6
-    tensor_parallel==1.1.0
+    tensor_parallel==1.0.23
     humanfriendly
     async-timeout>=4.0.2
     cpufeature>=0.2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     bitsandbytes==0.37.1
     accelerate==0.15.0
     huggingface-hub==0.11.1
-    transformers==4.25.1
+    transformers>=4.25.1,<5.0.0
     speedtest-cli==2.1.3
     hivemind==1.1.6
     tensor_parallel==1.0.23

--- a/src/petals/bloom/block.py
+++ b/src/petals/bloom/block.py
@@ -5,13 +5,15 @@ See commit history for authorship.
 """
 import os
 from typing import Optional, Tuple
+from packaging import version
 
 import torch.nn.quantized.dynamic.modules.linear
 import transformers
 from transformers.models.bloom.modeling_bloom import BloomBlock, _expand_mask, _make_causal_mask, build_alibi_tensor
 
 if not os.getenv("PETALS_IGNORE_DEPENDENCY_VERSION"):
-    assert transformers.__version__.startswith("4.25."), "Please install transformers 4.25.1"
+    assert version.parse("4.26.0") < version.parse(transformers.__version__) < version.parse("5.0.0"), \
+        "Please install transformers >=4.26.0,<5.0.0"
 
 
 class WrappedBloomBlock(BloomBlock):

--- a/src/petals/bloom/block.py
+++ b/src/petals/bloom/block.py
@@ -5,15 +5,16 @@ See commit history for authorship.
 """
 import os
 from typing import Optional, Tuple
-from packaging import version
 
 import torch.nn.quantized.dynamic.modules.linear
 import transformers
+from packaging import version
 from transformers.models.bloom.modeling_bloom import BloomBlock, _expand_mask, _make_causal_mask, build_alibi_tensor
 
 if not os.getenv("PETALS_IGNORE_DEPENDENCY_VERSION"):
-    assert version.parse("4.26.0") < version.parse(transformers.__version__) < version.parse("5.0.0"), \
-        "Please install transformers >=4.26.0,<5.0.0"
+    assert (
+        version.parse("4.26.0") < version.parse(transformers.__version__) < version.parse("5.0.0")
+    ), "Please install transformers >=4.26.0,<5.0.0"
 
 
 class WrappedBloomBlock(BloomBlock):

--- a/src/petals/bloom/block.py
+++ b/src/petals/bloom/block.py
@@ -14,7 +14,7 @@ from transformers.models.bloom.modeling_bloom import BloomBlock, _expand_mask, _
 if not os.getenv("PETALS_IGNORE_DEPENDENCY_VERSION"):
     assert (
         version.parse("4.26.0") < version.parse(transformers.__version__) < version.parse("5.0.0")
-    ), "Please install transformers >=4.26.0,<5.0.0"
+    ), "Please install a proper transformers version: pip install transformers>=4.26.0,<5.0.0"
 
 
 class WrappedBloomBlock(BloomBlock):


### PR DESCRIPTION
- new bitsandbytes supports newer *and* older GPUs
- new hivemind supports a better bfloat16 codec

Future work:
- [ ] remove CustomLinear8bitlt
- [ ] check bnb backward without memory_efficient_backward