### PR TITLE
Refactor RemoteSequenceManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ See the instructions for macOS and Windows, the full requirements, and troublesh
 
 ## Benchmarks
 
+The benchmarks below are for BLOOM-176B:
+
 <table align="center">
   <tr>
     <th colspan="2">Network</th>

--- a/src/petals/client/__init__.py
+++ b/src/petals/client/__init__.py
@@ -5,6 +5,6 @@ from petals.client.remote_model import (
     DistributedBloomForSequenceClassification,
     DistributedBloomModel,
 )
-from petals.client.remote_sequential import RemoteSequential, RemoteTransformerBlock
+from petals.client.remote_sequential import RemoteSequential
 from petals.client.routing.sequence_manager import RemoteSequenceManager
 from petals.client.routing.spending_policy import NoSpendingPolicy, SpendingPolicyBase

--- a/src/petals/client/inference_session.py
+++ b/src/petals/client/inference_session.py
@@ -8,7 +8,6 @@ from typing import AsyncIterator, List, Optional
 
 import torch
 from hivemind import (
-    P2P,
     MSGPackSerializer,
     anext,
     deserialize_torch_tensor,
@@ -162,9 +161,8 @@ class InferenceSession:
     An interface to a multi-step *inference* session for a sequence of remote transformer blocks
     """
 
-    def __init__(self, sequence_manager: RemoteSequenceManager, p2p: P2P, max_length: int):
+    def __init__(self, sequence_manager: RemoteSequenceManager, max_length: int):
         self._sequence_manager = sequence_manager
-        self._p2p = p2p
         self._closed = False
         self._chosen_spans = []
         self._server_sessions = []
@@ -181,7 +179,7 @@ class InferenceSession:
         server_sessions = []
         try:
             for span in chosen_spans:
-                stub = TransformerConnectionHandler.get_stub(self._p2p, span.peer_id)
+                stub = TransformerConnectionHandler.get_stub(self._sequence_manager.state.p2p, span.peer_id)
                 span_uids = CHAIN_DELIMITER.join(self._sequence_manager.block_uids[span.start : span.end])
                 metadata = self._sequence_manager.get_request_metadata("rpc_inference", span_uids, peer_id=span.peer_id)
                 session = RemoteExpertWorker.run_coroutine(

--- a/src/petals/client/inference_session.py
+++ b/src/petals/client/inference_session.py
@@ -305,8 +305,7 @@ class InferenceSession:
                     self._sequence_manager.on_request_success(span.peer_id)
                     break
                 except Exception as e:
-                    if span is not None:
-                        self._sequence_manager.on_request_failure(span.peer_id)
+                    self._sequence_manager.on_request_failure(span.peer_id if span is not None else None)
                     if attempt_no + 1 == self._sequence_manager.max_retries:
                         raise
                     delay = self._sequence_manager.get_retry_delay(attempt_no)

--- a/src/petals/client/inference_session.py
+++ b/src/petals/client/inference_session.py
@@ -189,7 +189,7 @@ class InferenceSession:
                         stub,
                         span_uids,
                         rpc_info=self._sequence_manager.rpc_info,
-                        timeout=self._sequence_manager.request_timeout,
+                        timeout=self._sequence_manager.config.request_timeout,
                         max_length=self._max_length,
                         **metadata,
                     )
@@ -306,7 +306,7 @@ class InferenceSession:
                     break
                 except Exception as e:
                     self._sequence_manager.on_request_failure(span.peer_id if span is not None else None)
-                    if attempt_no + 1 == self._sequence_manager.max_retries:
+                    if attempt_no + 1 == self._sequence_manager.config.max_retries:
                         raise
                     delay = self._sequence_manager.get_retry_delay(attempt_no)
                     logger.warning(

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -122,11 +122,7 @@ class DistributedBloomModel(_FromPretrainedDefaultsMixin, BloomModel):
                 start=True,
             )
         assert isinstance(dht, hivemind.DHT) and dht.is_alive(), "dht must be a running hivemind.DHT instance"
-        self.h = RemoteSequential(
-            config,
-            dht,
-            config.dht_prefix,
-        )
+        self.h = RemoteSequential(config, dht)
 
         # Forbid accumulate grads for embeddings and layernorm
         self.set_requires_grad(False)

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -18,13 +18,14 @@ from transformers.models.bloom import (
 from petals.bloom.modeling_utils import LMHead
 from petals.client.remote_generation import RemoteGenerationMixin
 from petals.client.remote_sequential import RemoteSequential
+from petals.client.routing.sequence_manager import SequenceManagerConfig
 from petals.constants import PUBLIC_INITIAL_PEERS
 from petals.utils.misc import DUMMY
 
 logger = get_logger(__name__)
 
 
-class DistributedBloomConfig(BloomConfig):
+class DistributedBloomConfig(BloomConfig, SequenceManagerConfig):
     """
     A bloom config that contains information about DHT peers.
     To create a distributed model, one must provide dht_prefix and either initial_peers or dht.
@@ -32,16 +33,12 @@ class DistributedBloomConfig(BloomConfig):
 
     initial_peers: List[str] = PUBLIC_INITIAL_PEERS  # a list of initial peers for hivemind DHT
     dht_prefix: str  # a prefix for all dht keys that correspond to this model (usually equal to model name)
-    daemon_startup_timeout: int = 60  # timeout for the libp2p daemon connecting to initial peers
+
     dht: Optional[hivemind.DHT] = None  # a running DHT instance, e.g. when using the same DHT for multiple models
-    request_timeout: int = 3 * 60  # a number of seconds for waiting result from each node
-    max_retries: Optional[int] = None  # max number retries before the client raises an exception (default: inf)
-    allowed_servers: Optional[
-        Collection[Union[str, hivemind.PeerID]]
-    ] = None  # if defined, send requests only to these servers
+    daemon_startup_timeout: int = 60  # timeout for the libp2p daemon connecting to initial peers
 
     pre_seq_len: int = 0  # a number of tokens for prompt tuning.
-    tuning_mode: Optional[str] = None  # One of the finetune options: [None, 'shallow_ptune', 'deep_ptune', 'adapters']
+    tuning_mode: Optional[str] = None  # fine-tuning regime, one of [None, "ptune", "deep_ptune"]
 
     # This settings matter for running the client with dtype bfloat16 on CPU.
     # If the CPU doesn't support AVX512, chunked_forward() significantly speeds up computations.

--- a/src/petals/client/remote_model.py
+++ b/src/petals/client/remote_model.py
@@ -101,7 +101,7 @@ class DistributedBloomModel(_FromPretrainedDefaultsMixin, BloomModel):
 
     config_class = DistributedBloomConfig
 
-    def __init__(self, config: DistributedBloomConfig, dht: Optional[hivemind.DHT] = None):
+    def __init__(self, config: DistributedBloomConfig, *, dht: Optional[hivemind.DHT] = None):
         assert config.dht_prefix, "Could not find dht_prefix in config, please create model with dht_prefix=..."
         assert config.initial_peers or dht is not None, "Please specify `config.initial_peers` or `dht`"
 
@@ -110,16 +110,7 @@ class DistributedBloomModel(_FromPretrainedDefaultsMixin, BloomModel):
         assert len(self.h) == 0
         config.n_layer = n_layer
 
-        if dht is None:
-            dht = hivemind.DHT(
-                initial_peers=config.initial_peers,
-                client_mode=True,
-                num_workers=n_layer,
-                startup_timeout=config.daemon_startup_timeout,
-                start=True,
-            )
-        assert isinstance(dht, hivemind.DHT) and dht.is_alive(), "dht must be a running hivemind.DHT instance"
-        self.h = RemoteSequential(config, dht)
+        self.h = RemoteSequential(config, dht=dht)
 
         # Forbid accumulate grads for embeddings and layernorm
         self.set_requires_grad(False)

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -48,21 +48,12 @@ class RemoteSequential(nn.Module):
         return outputs
 
     def __getitem__(self, ix: Union[int, slice]) -> RemoteSequential:
-        assert isinstance(ix, (int, slice))
-        if isinstance(ix, int):
-            return RemoteTransformerBlock(
-                self.config,
-                self.dht,
-                dht_prefix=self.dht_prefix,
-                sequence_manager=self.sequence_manager[ix],
-            )
-        else:
-            return RemoteSequential(
-                self.config,
-                self.dht,
-                dht_prefix=self.dht_prefix,
-                sequence_manager=self.sequence_manager[ix],
-            )
+        return RemoteSequential(
+            self.config,
+            self.dht,
+            dht_prefix=self.dht_prefix,
+            sequence_manager=self.sequence_manager[ix],
+        )
 
     def __iter__(self):
         for block_index in range(len(self)):
@@ -76,18 +67,3 @@ class RemoteSequential(nn.Module):
 
     def extra_repr(self) -> str:
         return f"modules={self.sequence_manager.block_uids[0]}..{self.sequence_manager.block_uids[-1]}"
-
-
-class RemoteTransformerBlock(RemoteSequential):
-    """Single transformer block hosted by swarm
-
-    This class is deprecated and kept for backward compatibility.
-    It will be removed soon in favor of using ``RemoteSequential`` directly.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        assert len(self) == 1, "Remote Block is a sequence size 1"
-
-    def extra_repr(self):
-        return f"{self.sequence_manager.block_uids[0]}"

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -26,19 +26,15 @@ class RemoteSequential(nn.Module):
         self,
         config: petals.client.DistributedBloomConfig,
         dht: DHT,
-        dht_prefix: Optional[str] = None,
         sequence_manager: Optional[RemoteSequenceManager] = None,
     ):
         super().__init__()
         self.config = config
         self.dht = dht
-        self.dht_prefix = dht_prefix or config.dht_prefix
-
-        num_blocks = self.config.n_layer if sequence_manager is None else len(sequence_manager)
-        block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(num_blocks))
 
         if sequence_manager is None:
-            sequence_manager = RemoteSequenceManager(dht, block_uids, config)
+            block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(self.config.n_layer))
+            sequence_manager = RemoteSequenceManager(config, dht, block_uids)
         self.sequence_manager = sequence_manager
 
     def forward(self, inputs: torch.Tensor, prompts: torch.Tensor = DUMMY):
@@ -51,7 +47,6 @@ class RemoteSequential(nn.Module):
         return RemoteSequential(
             self.config,
             self.dht,
-            dht_prefix=self.dht_prefix,
             sequence_manager=self.sequence_manager[ix],
         )
 

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -26,14 +26,24 @@ class RemoteSequential(nn.Module):
         self,
         config: petals.client.DistributedBloomConfig,
         dht: DHT,
+        *,
         sequence_manager: Optional[RemoteSequenceManager] = None,
+        start_block: Optional[int] = None,
+        end_block: Optional[int] = None,
     ):
         super().__init__()
         self.config = config
         self.dht = dht
 
+        assert sequence_manager is None or (
+            start_block is None and end_block is None
+        ), "`start_block` and `end_block` have no effect when `sequence_manager` is provided"
         if sequence_manager is None:
-            block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(self.config.n_layer))
+            if start_block is None:
+                start_block = 0
+            if end_block is None:
+                end_block = self.config.n_layer
+            block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(start_block, end_block))
             sequence_manager = RemoteSequenceManager(config, dht, block_uids)
         self.sequence_manager = sequence_manager
 

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -29,7 +29,6 @@ class RemoteSequential(nn.Module):
         dht_prefix: Optional[str] = None,
         p2p: Optional[P2P] = None,
         sequence_manager: Optional[RemoteSequenceManager] = None,
-        **kwargs,
     ):
         super().__init__()
         self.config = config
@@ -41,17 +40,7 @@ class RemoteSequential(nn.Module):
         block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(num_blocks))
 
         if sequence_manager is None:
-            sequence_manager = RemoteSequenceManager(
-                dht,
-                block_uids,
-                self.p2p,
-                request_timeout=config.request_timeout,
-                max_retries=config.max_retries,
-                allowed_servers=config.allowed_servers,
-                **kwargs,
-            )
-        elif kwargs:
-            logger.warning(f"Parameters {kwargs} are ignored because sequence_manager is explicitly provided")
+            sequence_manager = RemoteSequenceManager(dht, block_uids, self.p2p, config)
         self.sequence_manager = sequence_manager
 
     def forward(self, inputs: torch.Tensor, prompts: torch.Tensor = DUMMY):

--- a/src/petals/client/remote_sequential.py
+++ b/src/petals/client/remote_sequential.py
@@ -39,9 +39,9 @@ class RemoteSequential(nn.Module):
 
         num_blocks = self.config.n_layer if sequence_manager is None else len(sequence_manager)
         block_uids = tuple(f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(num_blocks))
+
         if sequence_manager is None:
-            logger.debug(f"Creating new sequence manager for block uids: {block_uids}")
-            self.sequence_manager = RemoteSequenceManager(
+            sequence_manager = RemoteSequenceManager(
                 dht,
                 block_uids,
                 self.p2p,
@@ -50,14 +50,9 @@ class RemoteSequential(nn.Module):
                 allowed_servers=config.allowed_servers,
                 **kwargs,
             )
-            self.is_subsequence = False
-        else:
-            logger.debug(f"Reusing sequence manager with {len(sequence_manager)} modules")
-            if kwargs:
-                logger.warning(f"Parameters {kwargs} are ignored because sequence_manager is explicitly provided")
-            self.sequence_manager = sequence_manager
-            assert isinstance(sequence_manager.sequence_info.block_uids, tuple)
-            self.is_subsequence = self.sequence_manager.sequence_info.block_uids != block_uids
+        elif kwargs:
+            logger.warning(f"Parameters {kwargs} are ignored because sequence_manager is explicitly provided")
+        self.sequence_manager = sequence_manager
 
     def forward(self, inputs: torch.Tensor, prompts: torch.Tensor = DUMMY):
         assert inputs.ndim == 3, "inputs must be a tensor of shape [batch_size, seq_length, hidden_size]"

--- a/src/petals/client/routing/sequence_info.py
+++ b/src/petals/client/routing/sequence_info.py
@@ -27,14 +27,14 @@ class RemoteSequenceInfo:
     block_infos: Tuple[RemoteModuleInfo, ...]  # note: the contents of RemoteModuleInfo can and will be updated
     spans_by_priority: List[RemoteSpanInfo]
     spans_containing_block: Tuple[List[RemoteSpanInfo], ...]
-    last_updated_time: float
+    last_updated_time: Optional[float]
 
     @classmethod
     def make_empty(cls: Type[T], block_uids: Iterable[ModuleUID]) -> T:
         block_uids = tuple(block_uids)
         empty_block_infos = tuple(RemoteModuleInfo(uid, {}) for uid in block_uids)
         empty_spans = tuple([] for _ in range(len(block_uids)))
-        return cls(block_uids, empty_block_infos, [], empty_spans, last_updated_time=-float("inf"))
+        return cls(block_uids, empty_block_infos, [], empty_spans, last_updated_time=None)
 
     def __getitem__(self, ix: slice):
         assert isinstance(ix, slice)

--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -267,7 +267,9 @@ class RemoteSequenceManager:
                 peer_id = random.choice(active_servers)
 
                 stub = TransformerConnectionHandler.get_stub(self.state.p2p, peer_id)
-                outputs = RemoteExpertWorker.run_coroutine(stub.rpc_info(runtime_pb2.ExpertUID(uid=self.block_uids[0])))
+                outputs = RemoteExpertWorker.run_coroutine(
+                    stub.rpc_info(runtime_pb2.ExpertUID(uid=self.block_uids[0]), timeout=self.config.request_timeout)
+                )
                 self.state.rpc_info = MSGPackSerializer.loads(outputs.serialized_info)
                 self.on_request_success(peer_id)
                 break

--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -76,8 +76,9 @@ class RemoteSequenceManager:
         self.dht = dht
         assert len(block_uids) > 0, "Sequences must contain at least one block"
 
-        assert config.allowed_servers is None or all(isinstance(item, PeerID) for item in config.allowed_servers), \
-            "config.allowed_servers should be None or a collection of hivemind.PeerIDs"
+        assert config.allowed_servers is None or all(
+            isinstance(item, PeerID) for item in config.allowed_servers
+        ), "config.allowed_servers should be None or a collection of hivemind.PeerIDs"
         self.config = config
         if state is None:
             state = SequenceManagerState()
@@ -264,9 +265,7 @@ class RemoteSequenceManager:
                 peer_id = random.choice(active_servers)
 
                 stub = TransformerConnectionHandler.get_stub(self.state.p2p, peer_id)
-                outputs = RemoteExpertWorker.run_coroutine(
-                    stub.rpc_info(runtime_pb2.ExpertUID(uid=self.block_uids[0]))
-                )
+                outputs = RemoteExpertWorker.run_coroutine(stub.rpc_info(runtime_pb2.ExpertUID(uid=self.block_uids[0])))
                 self.state.rpc_info = MSGPackSerializer.loads(outputs.serialized_info)
                 self.on_request_success(peer_id)
                 break

--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -28,7 +28,7 @@ logger = get_logger(__name__)
 
 @dataclasses.dataclass
 class SequenceManagerConfig:
-    allowed_servers: Optional[Collection[PeerID]] = None  # if defined, send requests only to these servers
+    allowed_servers: Optional[Collection[Union[PeerID, str]]] = None  # if defined, send requests only to these servers
 
     request_timeout: float = 3 * 60  # timeout for forward/backward/inference requests
     update_period: float = 60  # refresh DHT information once in this many seconds
@@ -76,9 +76,6 @@ class RemoteSequenceManager:
         self.dht = dht
         assert len(block_uids) > 0, "Sequences must contain at least one block"
 
-        assert config.allowed_servers is None or all(
-            isinstance(item, PeerID) for item in config.allowed_servers
-        ), "config.allowed_servers should be None or a collection of hivemind.PeerIDs"
         self.config = config
         if state is None:
             state = SequenceManagerState()
@@ -177,7 +174,7 @@ class RemoteSequenceManager:
                 block_info.servers = {
                     peer_id: server_info
                     for peer_id, server_info in block_info.servers.items()
-                    if peer_id in self.config.allowed_servers
+                    if peer_id in self.config.allowed_servers or str(peer_id) in self.config.allowed_servers
                 }
 
             # Remove temporarily banned peers, unless there are no peers left

--- a/src/petals/client/routing/sequence_manager.py
+++ b/src/petals/client/routing/sequence_manager.py
@@ -67,9 +67,9 @@ class RemoteSequenceManager:
 
     def __init__(
         self,
+        config: SequenceManagerConfig,
         dht: DHT,
         block_uids: Sequence[ModuleUID],
-        config: SequenceManagerConfig,
         *,
         state: Optional[SequenceManagerState] = None,
     ):
@@ -152,12 +152,7 @@ class RemoteSequenceManager:
         assert isinstance(ix, (int, slice))
         if not isinstance(ix, slice):
             ix = slice(int(ix), int(ix) + 1, 1)
-        return type(self)(
-            self.dht,
-            self.block_uids[ix],
-            self.config,
-            state=self.state[ix],
-        )
+        return type(self)(self.config, self.dht, self.block_uids[ix], state=self.state[ix])
 
     def update(self, *, wait: bool):
         """Run an asynchronous update in background as soon as possible"""

--- a/src/petals/client/sequential_autograd.py
+++ b/src/petals/client/sequential_autograd.py
@@ -77,7 +77,7 @@ async def sequential_forward(
                     stub,
                     sequence_manager.rpc_info,
                     *inputs_and_prompts,
-                    timeout=sequence_manager.request_timeout,
+                    timeout=sequence_manager.config.request_timeout,
                     metadata=MSGPackSerializer.dumps(metadata),
                 )
 
@@ -94,7 +94,7 @@ async def sequential_forward(
                 break
             except Exception as e:
                 sequence_manager.on_request_failure(span.peer_id if span is not None else None)
-                if attempt_no + 1 == sequence_manager.max_retries:
+                if attempt_no + 1 == sequence_manager.config.max_retries:
                     raise
                 delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(
@@ -162,7 +162,7 @@ async def sequential_backward(
                     inputs,
                     grad_outputs,
                     prompts[span.start : span.end],
-                    timeout=sequence_manager.request_timeout,
+                    timeout=sequence_manager.config.request_timeout,
                     metadata=MSGPackSerializer.dumps(metadata),
                 )
                 grad_outputs = [grad_outputs]
@@ -171,7 +171,7 @@ async def sequential_backward(
                 break
             except Exception as e:
                 sequence_manager.on_request_failure(span.peer_id if span is not None else None)
-                if attempt_no + 1 == sequence_manager.max_retries:
+                if attempt_no + 1 == sequence_manager.config.max_retries:
                     raise
                 delay = sequence_manager.get_retry_delay(attempt_no)
                 logger.warning(

--- a/src/petals/client/sequential_autograd.py
+++ b/src/petals/client/sequential_autograd.py
@@ -67,7 +67,7 @@ async def sequential_forward(
 
                 span = sequences.popleft()
 
-                stub = TransformerConnectionHandler.get_stub(sequence_manager.p2p, span.peer_id)
+                stub = TransformerConnectionHandler.get_stub(sequence_manager.state.p2p, span.peer_id)
                 inputs_and_prompts = [inputs, prompts[span.start : span.end]]
 
                 span_uids = CHAIN_DELIMITER.join(sequence_manager.block_uids[span.start : span.end])
@@ -151,7 +151,7 @@ async def sequential_backward(
                     span = forward_sequences.pop()
 
                 span_uids = CHAIN_DELIMITER.join(sequence_manager.block_uids[span.start : span.end])
-                stub = TransformerConnectionHandler.get_stub(sequence_manager.p2p, span.peer_id)
+                stub = TransformerConnectionHandler.get_stub(sequence_manager.state.p2p, span.peer_id)
                 metadata = sequence_manager.get_request_metadata(
                     "rpc_backward", span_uids, *inputs, *grad_outputs, peer_id=span.peer_id
                 )

--- a/src/petals/client/sequential_autograd.py
+++ b/src/petals/client/sequential_autograd.py
@@ -93,8 +93,7 @@ async def sequential_forward(
                 sequence_manager.on_request_success(span.peer_id)
                 break
             except Exception as e:
-                if span is not None:
-                    sequence_manager.on_request_failure(span.peer_id)
+                sequence_manager.on_request_failure(span.peer_id if span is not None else None)
                 if attempt_no + 1 == sequence_manager.max_retries:
                     raise
                 delay = sequence_manager.get_retry_delay(attempt_no)
@@ -171,8 +170,7 @@ async def sequential_backward(
                 sequence_manager.on_request_success(span.peer_id)
                 break
             except Exception as e:
-                if span is not None:
-                    sequence_manager.on_request_failure(span.peer_id)
+                sequence_manager.on_request_failure(span.peer_id if span is not None else None)
                 if attempt_no + 1 == sequence_manager.max_retries:
                     raise
                 delay = sequence_manager.get_retry_delay(attempt_no)

--- a/src/petals/dht_utils.py
+++ b/src/petals/dht_utils.py
@@ -93,7 +93,7 @@ async def _get_remote_sequence(
 ) -> petals.client.RemoteSequential:
     uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(start, stop)]
     p2p = await dht.replicate_p2p()
-    manager = petals.client.RemoteSequenceManager(dht, uids, p2p)
+    manager = petals.client.RemoteSequenceManager(dht, uids, p2p, config)
     return petals.client.RemoteSequential(config, dht, dht_prefix, p2p, manager)
 
 
@@ -124,7 +124,7 @@ async def _get_remote_module(
     single_uid = isinstance(uid_or_uids, ModuleUID)
     uids = [uid_or_uids] if single_uid else uid_or_uids
     p2p = await dht.replicate_p2p()
-    managers = (petals.client.RemoteSequenceManager(dht, [uid], p2p) for uid in uids)
+    managers = (petals.client.RemoteSequenceManager(dht, [uid], p2p, config) for uid in uids)
     modules = [
         petals.client.RemoteTransformerBlock(config, dht, dht_prefix=dht_prefix, p2p=p2p, sequence_manager=m)
         for m in managers

--- a/src/petals/dht_utils.py
+++ b/src/petals/dht_utils.py
@@ -97,41 +97,6 @@ async def _get_remote_sequence(
     return petals.client.RemoteSequential(config, dht, dht_prefix, p2p, manager)
 
 
-def get_remote_module(
-    dht: DHT,
-    uid_or_uids: Union[ModuleUID, List[ModuleUID]],
-    config: petals.client.DistributedBloomConfig,
-    dht_prefix: Optional[str] = None,
-    return_future: bool = False,
-) -> Union[Union[petals.client.RemoteTransformerBlock, List[petals.client.RemoteTransformerBlock]], MPFuture]:
-    """
-    :param uid_or_uids: find one or more modules with these ids from across the DHT
-    :param config: model config, usually taken by .from_pretrained(MODEL_NAME)
-    :param return_future: if False (default), return when finished. Otherwise return MPFuture and run in background.
-    :returns: a list of [RemoteTransformerBlock]
-    """
-    return RemoteExpertWorker.run_coroutine(
-        _get_remote_module(dht, uid_or_uids, config, dht_prefix), return_future=return_future
-    )
-
-
-async def _get_remote_module(
-    dht: DHT,
-    uid_or_uids: Union[ModuleUID, List[ModuleUID]],
-    config: petals.client.DistributedBloomConfig,
-    dht_prefix: Optional[str] = None,
-) -> Union[petals.client.RemoteTransformerBlock, List[petals.client.RemoteTransformerBlock]]:
-    single_uid = isinstance(uid_or_uids, ModuleUID)
-    uids = [uid_or_uids] if single_uid else uid_or_uids
-    p2p = await dht.replicate_p2p()
-    managers = (petals.client.RemoteSequenceManager(dht, [uid], p2p, config) for uid in uids)
-    modules = [
-        petals.client.RemoteTransformerBlock(config, dht, dht_prefix=dht_prefix, p2p=p2p, sequence_manager=m)
-        for m in managers
-    ]
-    return modules[0] if single_uid else modules
-
-
 def get_remote_module_infos(
     dht: DHT,
     uids: Sequence[ModuleUID],

--- a/src/petals/dht_utils.py
+++ b/src/petals/dht_utils.py
@@ -71,17 +71,6 @@ async def _declare_active_modules(
     )
 
 
-def get_remote_sequence(
-    dht: DHT,
-    start: int,
-    stop: int,
-    config: petals.client.DistributedBloomConfig,
-) -> petals.client.RemoteSequential:
-    block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(start, stop)]
-    manager = petals.client.RemoteSequenceManager(config, dht, block_uids)
-    return petals.client.RemoteSequential(config, dht, manager)
-
-
 def get_remote_module_infos(
     dht: DHT,
     uids: Sequence[ModuleUID],

--- a/src/petals/dht_utils.py
+++ b/src/petals/dht_utils.py
@@ -76,25 +76,10 @@ def get_remote_sequence(
     start: int,
     stop: int,
     config: petals.client.DistributedBloomConfig,
-    dht_prefix: Optional[str] = None,
-    return_future: bool = False,
-) -> Union[petals.client.RemoteSequential, MPFuture]:
-    return RemoteExpertWorker.run_coroutine(
-        _get_remote_sequence(dht, start, stop, config, dht_prefix), return_future=return_future
-    )
-
-
-async def _get_remote_sequence(
-    dht: DHT,
-    start: int,
-    stop: int,
-    config: petals.client.DistributedBloomConfig,
-    dht_prefix: Optional[str] = None,
 ) -> petals.client.RemoteSequential:
-    uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(start, stop)]
-    p2p = await dht.replicate_p2p()
-    manager = petals.client.RemoteSequenceManager(dht, uids, p2p, config)
-    return petals.client.RemoteSequential(config, dht, dht_prefix, p2p, manager)
+    block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(start, stop)]
+    manager = petals.client.RemoteSequenceManager(config, dht, block_uids)
+    return petals.client.RemoteSequential(config, dht, manager)
 
 
 def get_remote_module_infos(

--- a/tests/test_block_exact_match.py
+++ b/tests/test_block_exact_match.py
@@ -10,7 +10,7 @@ from petals.bloom.block import WrappedBloomBlock
 from petals.bloom.from_pretrained import DTYPE_MAP, _load_state_dict, load_pretrained_block
 from petals.client import DistributedBloomConfig
 from petals.data_structures import UID_DELIMITER
-from petals.dht_utils import get_remote_module
+from petals.dht_utils import get_remote_sequence
 from test_utils import *
 
 

--- a/tests/test_block_exact_match.py
+++ b/tests/test_block_exact_match.py
@@ -1,7 +1,6 @@
 import random
 from typing import Union
 
-import hivemind
 import pytest
 import torch
 from transformers.models.bloom.configuration_bloom import BloomConfig
@@ -15,9 +14,8 @@ from test_utils import *
 
 @pytest.mark.forked
 def test_remote_block_exact_match(atol_forward=1e-4, atol_inference=1e-3):
-    config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
-    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
-    remote_sequential = RemoteSequential(config, dht)
+    config = DistributedBloomConfig.from_pretrained(MODEL_NAME, initial_peers=INITIAL_PEERS)
+    remote_sequential = RemoteSequential(config)
 
     for block_index in random.sample(range(config.n_layer), 3):
         remote_block = remote_sequential[block_index]

--- a/tests/test_block_exact_match.py
+++ b/tests/test_block_exact_match.py
@@ -9,7 +9,6 @@ from transformers.models.bloom.configuration_bloom import BloomConfig
 from petals.bloom.block import WrappedBloomBlock
 from petals.bloom.from_pretrained import DTYPE_MAP, _load_state_dict, load_pretrained_block
 from petals.client import DistributedBloomConfig
-from petals.client.remote_sequential import RemoteTransformerBlock
 from petals.data_structures import UID_DELIMITER
 from petals.dht_utils import get_remote_module
 from test_utils import *
@@ -21,9 +20,7 @@ def test_remote_block_exact_match(atol_forward=1e-4, atol_inference=1e-3):
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
 
     for block_index in random.sample(range(config.n_layer), 3):
-        remote_block = get_remote_module(dht, f"{MODEL_NAME}{UID_DELIMITER}{block_index}", config)
-        assert isinstance(remote_block, RemoteTransformerBlock)
-
+        remote_block = get_remote_sequence(dht, block_index, block_index + 1, config)
         inputs = torch.randn(1, 8, config.hidden_size)
         outputs_forward = remote_block(inputs)
 

--- a/tests/test_block_exact_match.py
+++ b/tests/test_block_exact_match.py
@@ -8,7 +8,7 @@ from transformers.models.bloom.configuration_bloom import BloomConfig
 
 from petals.bloom.block import WrappedBloomBlock
 from petals.bloom.from_pretrained import DTYPE_MAP, _load_state_dict, load_pretrained_block
-from petals.client import DistributedBloomConfig
+from petals.client import DistributedBloomConfig, RemoteSequential
 from petals.data_structures import UID_DELIMITER
 from test_utils import *
 

--- a/tests/test_block_exact_match.py
+++ b/tests/test_block_exact_match.py
@@ -10,17 +10,18 @@ from petals.bloom.block import WrappedBloomBlock
 from petals.bloom.from_pretrained import DTYPE_MAP, _load_state_dict, load_pretrained_block
 from petals.client import DistributedBloomConfig
 from petals.data_structures import UID_DELIMITER
-from petals.dht_utils import get_remote_sequence
 from test_utils import *
 
 
 @pytest.mark.forked
 def test_remote_block_exact_match(atol_forward=1e-4, atol_inference=1e-3):
-    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
+    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
+    remote_sequential = RemoteSequential(config, dht)
 
     for block_index in random.sample(range(config.n_layer), 3):
-        remote_block = get_remote_sequence(dht, block_index, block_index + 1, config)
+        remote_block = remote_sequential[block_index]
+
         inputs = torch.randn(1, 8, config.hidden_size)
         outputs_forward = remote_block(inputs)
 
@@ -33,7 +34,6 @@ def test_remote_block_exact_match(atol_forward=1e-4, atol_inference=1e-3):
             with pytest.raises(ValueError, match=r"Maximum length exceeded") as exc_info:
                 sess.step(inputs[:, -1:, :])
             assert "Maximum length exceeded" in repr(exc_info.value)
-
         outputs_inference = torch.cat(outputs_inference, dim=1)
 
         ref_block = load_pretrained_block(MODEL_NAME, block_index, torch_dtype=torch.float32)

--- a/tests/test_chained_calls.py
+++ b/tests/test_chained_calls.py
@@ -4,7 +4,6 @@
 # - if you want to figure out chained inference, ask yozh
 
 
-import hivemind
 import pytest
 import torch
 
@@ -16,9 +15,8 @@ from test_utils import *
 
 @pytest.mark.forked
 def test_forward_backward_exact_match(atol_forward=1e-4, atol_backward=1e-4, seq_length=1):
-    config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
-    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
-    remote_blocks = RemoteSequential(config, dht, start_block=3, end_block=6)
+    config = DistributedBloomConfig.from_pretrained(MODEL_NAME, initial_peers=INITIAL_PEERS)
+    remote_blocks = RemoteSequential(config, start_block=3, end_block=6)
     assert isinstance(remote_blocks, RemoteSequential)
 
     ref_blocks = [
@@ -45,9 +43,8 @@ def test_forward_backward_exact_match(atol_forward=1e-4, atol_backward=1e-4, seq
 
 @pytest.mark.forked
 def test_chained_inference_exact_match(atol_inference=1e-4):
-    config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
-    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
-    remote_blocks = RemoteSequential(config, dht, start_block=3, end_block=5)
+    config = DistributedBloomConfig.from_pretrained(MODEL_NAME, initial_peers=INITIAL_PEERS)
+    remote_blocks = RemoteSequential(config, start_block=3, end_block=5)
 
     inputs = torch.randn(1, 8, config.hidden_size)
 

--- a/tests/test_chained_calls.py
+++ b/tests/test_chained_calls.py
@@ -11,15 +11,14 @@ import torch
 from petals.bloom.from_pretrained import load_pretrained_block
 from petals.client import DistributedBloomConfig
 from petals.client.remote_sequential import RemoteSequential
-from petals.dht_utils import get_remote_sequence
 from test_utils import *
 
 
 @pytest.mark.forked
 def test_forward_backward_exact_match(atol_forward=1e-4, atol_backward=1e-4, seq_length=1):
-    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
-    remote_blocks = get_remote_sequence(dht, 3, 6, config)
+    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
+    remote_blocks = RemoteSequential(config, dht, start_block=3, end_block=6)
     assert isinstance(remote_blocks, RemoteSequential)
 
     ref_blocks = [
@@ -46,10 +45,9 @@ def test_forward_backward_exact_match(atol_forward=1e-4, atol_backward=1e-4, seq
 
 @pytest.mark.forked
 def test_chained_inference_exact_match(atol_inference=1e-4):
-    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
-    remote_blocks = get_remote_sequence(dht, 3, 5, config)
-    assert isinstance(remote_blocks, RemoteSequential)
+    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
+    remote_blocks = RemoteSequential(config, dht, start_block=3, end_block=5)
 
     inputs = torch.randn(1, 8, config.hidden_size)
 

--- a/tests/test_remote_sequential.py
+++ b/tests/test_remote_sequential.py
@@ -48,7 +48,7 @@ def test_remote_sequential():
     # test RemoteSequential with lossy compression
     block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(config.n_layer)]
     lossy_sequential = RemoteSequential(
-        config, dht, sequence_manager=DummyCustomSequenceManager(dht, block_uids, sequential.p2p)
+        config, dht, sequence_manager=DummyCustomSequenceManager(dht, block_uids, config)
     )
 
     test_inputs.grad = None

--- a/tests/test_remote_sequential.py
+++ b/tests/test_remote_sequential.py
@@ -48,7 +48,7 @@ def test_remote_sequential():
     # test RemoteSequential with lossy compression
     block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(config.n_layer)]
     lossy_sequential = RemoteSequential(
-        config, dht, sequence_manager=DummyCustomSequenceManager(dht, block_uids, config)
+        config, dht, sequence_manager=DummyCustomSequenceManager(config, dht, block_uids)
     )
 
     test_inputs.grad = None

--- a/tests/test_remote_sequential.py
+++ b/tests/test_remote_sequential.py
@@ -20,7 +20,7 @@ def test_remote_sequential():
     test_inputs = torch.randn(1, 5, config.hidden_size, requires_grad=True)
     grad_proj = torch.randn(1, 5, config.hidden_size)
 
-    sequential = RemoteSequential(config, dht)
+    sequential = RemoteSequential(config, dht=dht)
 
     full_outputs = sequential(test_inputs)
     (full_outputs * grad_proj).sum().backward()
@@ -48,7 +48,7 @@ def test_remote_sequential():
     # test RemoteSequential with lossy compression
     block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(config.n_layer)]
     lossy_sequential = RemoteSequential(
-        config, dht, sequence_manager=DummyCustomSequenceManager(config, dht, block_uids)
+        config, sequence_manager=DummyCustomSequenceManager(config, block_uids, dht=dht)
     )
 
     test_inputs.grad = None
@@ -85,8 +85,7 @@ class DummyCustomSequenceManager(RemoteSequenceManager):
 @pytest.mark.forked
 def test_remote_sequential_prompts(batch_size=2, seq_len=5, pre_seq_len=3):
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME, initial_peers=INITIAL_PEERS)
-    dht = DHT(initial_peers=config.initial_peers, client_mode=True, start=True)
-    remote_sequential = RemoteSequential(config, dht)
+    remote_sequential = RemoteSequential(config)
 
     inputs = F.normalize(torch.randn(batch_size, seq_len, config.hidden_size), dim=-1)
     output_proj = F.normalize(torch.randn(batch_size, seq_len + pre_seq_len, config.hidden_size), dim=-1)

--- a/tests/test_sequence_manager.py
+++ b/tests/test_sequence_manager.py
@@ -26,7 +26,7 @@ def test_sequence_manager_basics(mode: str):
     sequential = RemoteSequential(
         config,
         dht,
-        sequence_manager=TestSequenceManager(dht, block_uids, sequential.p2p, _was_shut_down=shutdown_evt),
+        sequence_manager=TestSequenceManager(dht, block_uids, _was_shut_down=shutdown_evt),
     )
 
     sequence = sequential.sequence_manager.make_sequence(mode=mode)

--- a/tests/test_sequence_manager.py
+++ b/tests/test_sequence_manager.py
@@ -18,15 +18,14 @@ logger = get_logger(__name__)
 def test_sequence_manager_basics(mode: str):
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME, initial_peers=INITIAL_PEERS)
     dht = DHT(initial_peers=config.initial_peers, client_mode=True, start=True)
-    sequential = RemoteSequential(config, dht)
+    sequential = RemoteSequential(config, dht=dht)
     shutdown_evt = threading.Event()
 
     # test RemoteSequential with lossy compression
     block_uids = [f"{config.dht_prefix}{UID_DELIMITER}{i}" for i in range(config.n_layer)]
     sequential = RemoteSequential(
         config,
-        dht,
-        sequence_manager=TestSequenceManager(config, dht, block_uids, _was_shut_down=shutdown_evt),
+        sequence_manager=TestSequenceManager(config, block_uids, dht=dht, _was_shut_down=shutdown_evt),
     )
 
     sequence = sequential.sequence_manager.make_sequence(mode=mode)

--- a/tests/test_sequence_manager.py
+++ b/tests/test_sequence_manager.py
@@ -26,7 +26,7 @@ def test_sequence_manager_basics(mode: str):
     sequential = RemoteSequential(
         config,
         dht,
-        sequence_manager=TestSequenceManager(dht, block_uids, _was_shut_down=shutdown_evt),
+        sequence_manager=TestSequenceManager(config, dht, block_uids, _was_shut_down=shutdown_evt),
     )
 
     sequence = sequential.sequence_manager.make_sequence(mode=mode)

--- a/tests/test_server_stats.py
+++ b/tests/test_server_stats.py
@@ -14,8 +14,8 @@ from test_utils import *
 def test_server_info(block_from: int = 22, block_to: int = 24, max_length: int = 100, max_length2: int = 50):
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
     dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
-    blocks1 = RemoteSequential(config, dht, start_block=block_from, end_block=block_to)
-    blocks2 = RemoteSequential(config, dht, start_block=block_to - 1, end_block=block_to)
+    blocks1 = RemoteSequential(config, dht=dht, start_block=block_from, end_block=block_to)
+    blocks2 = RemoteSequential(config, dht=dht, start_block=block_to - 1, end_block=block_to)
 
     info_before = blocks1.sequence_manager.rpc_info
 

--- a/tests/test_server_stats.py
+++ b/tests/test_server_stats.py
@@ -4,7 +4,7 @@ import hivemind
 import pytest
 import torch
 
-from petals.client import DistributedBloomConfig
+from petals.client import DistributedBloomConfig, RemoteSequential
 from petals.data_structures import UID_DELIMITER
 from petals.server.handler import CACHE_TOKENS_AVAILABLE
 from test_utils import *

--- a/tests/test_server_stats.py
+++ b/tests/test_server_stats.py
@@ -6,18 +6,17 @@ import torch
 
 from petals.client import DistributedBloomConfig
 from petals.data_structures import UID_DELIMITER
-from petals.dht_utils import get_remote_sequence
 from petals.server.handler import CACHE_TOKENS_AVAILABLE
 from test_utils import *
 
 
 @pytest.mark.forked
 def test_server_info(block_from: int = 22, block_to: int = 24, max_length: int = 100, max_length2: int = 50):
-    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
+    dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
+    blocks1 = RemoteSequential(config, dht, start_block=block_from, end_block=block_to)
+    blocks2 = RemoteSequential(config, dht, start_block=block_to - 1, end_block=block_to)
 
-    blocks1 = get_remote_sequence(dht, block_from, block_to, config)
-    blocks2 = get_remote_sequence(dht, block_to - 1, block_to, config)
     info_before = blocks1.sequence_manager.rpc_info
 
     with blocks1.inference_session(max_length=max_length) as sess:

--- a/tests/test_server_stats.py
+++ b/tests/test_server_stats.py
@@ -16,22 +16,22 @@ def test_server_info(block_from: int = 22, block_to: int = 24, max_length: int =
     dht = hivemind.DHT(initial_peers=INITIAL_PEERS, client_mode=True, start=True)
     config = DistributedBloomConfig.from_pretrained(MODEL_NAME)
 
-    blocks1 = get_remote_sequence(dht, block_from, block_to, config, f"{MODEL_NAME}{UID_DELIMITER}")
-    blocks2 = get_remote_sequence(dht, block_to - 1, block_to, config, f"{MODEL_NAME}{UID_DELIMITER}")
+    blocks1 = get_remote_sequence(dht, block_from, block_to, config)
+    blocks2 = get_remote_sequence(dht, block_to - 1, block_to, config)
     info_before = blocks1.sequence_manager.rpc_info
 
     with blocks1.inference_session(max_length=max_length) as sess:
         sess.step(torch.randn(1, 1, config.hidden_size))
-        blocks1.sequence_manager._rpc_info = None  # invalidate cache
+        blocks1.sequence_manager.state.rpc_info = None  # invalidate cache
         info_inside = blocks1.sequence_manager.rpc_info
 
         with blocks2.inference_session(max_length=max_length2) as sess2:
             sess2.step(torch.randn(1, 1, config.hidden_size))
-            blocks2.sequence_manager._rpc_info = None  # invalidate cache
+            blocks2.sequence_manager.state.rpc_info = None  # invalidate cache
             info_inside2 = blocks2.sequence_manager.rpc_info
 
     time.sleep(0.1)
-    blocks1.sequence_manager._rpc_info = None  # invalidate cache
+    blocks1.sequence_manager.state.rpc_info = None  # invalidate cache
     info_after = blocks1.sequence_manager.rpc_info
 
     assert info_before[CACHE_TOKENS_AVAILABLE] == info_after[CACHE_TOKENS_AVAILABLE]


### PR DESCRIPTION
This PR:

1. **Extracts `SequenceManagerConfig` and `SequenceManagerState` subclasses.**

    The config is provided by caller and never changed from inside `RemoteSequenceManager`. The state is a part of the `RemoteSequenceManager`'s state shared between the main manager and its slices. We fix some slicing bugs along the way.

2. **Removes `dht_prefix` and `p2p` arguments, makes `dht` argument optional.**

    `dht_prefix` can always be overridden using `config.dht_prefix`. `p2p` actually needed only under the hood of `RemoteSequenceManager`, so it can extract it by itself without exposing this low-level class to callers. If strictly necessary, a caller can provide `p2p` as a part of `SequenceManagerState`. `dht` is also needed only by `RemoteSequenceManager`, so we can make it optional in the parent classes and create it automatically when it's not provided.

3. **Simplifies retry logic.**

    Previously, we could have "nested" retry loops: one in `._update()`, another in inference/forward/backward steps. The loop in `._update()` could introduce issues to concurrent inference/forward/backward calls, since it blocks the entire class if its delay period becomes too high. Now this logic is simplified: `._update()` performs only one attempt to fetch the DHT info, any retries are triggered by the inference/forward/backward steps.

4. **Removes deprecated `RemoteTransformerBlock`.**

    `RemoteTransformerBlock` was deprecated a long time ago, before Petals 1.0.0. Its removal is long due.

5. **Removes `dht_utils.get_remote_module()`, `dht_utils.get_remote_sequence()`.**

    This functions duplicate the functionality of the `RemoteSequential` constructor.

6. (minor) **Removes `RemoteSequential.is_subsequence` flag.**

    This flag worked incorrectly and was never used. I am removing it for the sake of simplicity.