### PR TITLE
Require pydantic < 2.0 (2.0 is incompatible with hivemind 1.1.8)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     tokenizers>=0.13.3
     transformers>=4.30.1,<5.0.0
     speedtest-cli==2.1.3
+    pydantic>=1.8.1,<2.0  # 2.0 is incompatible with hivemind==1.1.8
     hivemind==1.1.8
     tensor_parallel==1.0.23
     humanfriendly


### PR DESCRIPTION
See https://github.com/learning-at-home/hivemind/pull/573.