### PR TITLE
Estimate adapter memory overhead in choose_num_blocks()

### DIFF
--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -253,7 +253,7 @@ class Server:
         if adapters:
             # Delay import of petals.utils.peft to avoid unnecessary import of bitsandbytes
             from petals.utils.peft import estimate_adapter_memory_per_block
-            
+
             adapter_memory_per_block = estimate_adapter_memory_per_block(
                 self.block_config, self.torch_dtype, self.adapters, self.cache_dir
             )

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -250,9 +250,13 @@ class Server:
         # Estimate of GPU memory used in rpc_backward (2 GiB for BLOOM, proportional for other models)
         autograd_memory = 2 * gib * num_devices / 14336 * self.block_config.hidden_size
 
-        adapter_memory_per_block = estimate_adapter_memory_per_block(
-            self.block_config, self.torch_dtype, self.adapters, self.cache_dir
-        )
+        if adapters:
+            # Delay import of petals.utils.peft to avoid unnecessary import of bitsandbytes
+            from petals.utils.peft import estimate_adapter_memory_per_block
+            
+            adapter_memory_per_block = estimate_adapter_memory_per_block(
+                self.block_config, self.torch_dtype, self.adapters, self.cache_dir
+            )
         total_memory_per_block = block_size + adapter_memory_per_block + self._cache_bytes_per_block
 
         num_blocks = math.floor((total_memory - autograd_memory) / total_memory_per_block)

--- a/src/petals/utils/convert_block.py
+++ b/src/petals/utils/convert_block.py
@@ -55,8 +55,6 @@ def convert_block(
         shard.to(device)
 
     if adapters:
-        # Import petals.utils.peft only when necessary to avoid importing bitsandbytes
-        os.environ["BITSANDBYTES_NOWELCOME"] = "1"
         from petals.utils.peft import add_adapter_to_block, create_lora_adapter, load_peft
 
         create_lora_adapter(block, quant_type=quant_type)

--- a/src/petals/utils/peft.py
+++ b/src/petals/utils/peft.py
@@ -1,9 +1,13 @@
 import re
 import time
-from typing import List, Optional
+from typing import List, Optional, Sequence
 
 import bitsandbytes as bnb
+import peft
+import torch
 import torch.nn as nn
+import transformers
+from accelerate import init_empty_weights
 from hivemind.utils.logging import get_logger
 from huggingface_hub import HfFileSystem, get_hf_file_metadata, hf_hub_url
 from peft.tuners import lora
@@ -12,6 +16,8 @@ from safetensors import safe_open
 from safetensors.torch import load_file
 from transformers.utils import get_file_from_repo
 
+from petals.client.ptune import force_non_empty_weights
+from petals.server.block_utils import resolve_block_dtype
 from petals.utils.disk_cache import allow_cache_reads, allow_cache_writes, free_disk_space_for
 from petals.utils.misc import QuantType
 
@@ -194,15 +200,35 @@ def add_adapter_to_block(block, block_index, adapter_name, peft_config, peft_sta
                             p.requires_grad = False
 
                     if peft_key.endswith(".lora_A.weight"):
-                        child.lora_A[adapter_name].weight.data = peft_state_dict[peft_key]
+                        child.lora_A[adapter_name].weight[...] = peft_state_dict[peft_key]
                         is_lora_a_loaded = True
                     elif peft_key.endswith(".lora_A.bias"):
                         raise NotImplementedError(f"LoRA adapters with bias not supported: {peft_key}")
                     elif peft_key.endswith(".lora_B.weight"):
-                        child.lora_B[adapter_name].weight.data = peft_state_dict[peft_key]
+                        child.lora_B[adapter_name].weight[...] = peft_state_dict[peft_key]
                         is_lora_b_loaded = True
                     elif peft_key.endswith(".lora_B.bias"):
                         raise NotImplementedError(f"LoRA adapters with bias not supported: {peft_key}")
 
                 if is_lora_a_loaded and is_lora_b_loaded:
                     logger.info(f"Loading {adapter_name} for block {block_index}.{child_name} is ended successfully")
+
+
+def estimate_adapter_memory_per_block(
+    block_config: transformers.PretrainedConfig, torch_dtype: Optional[torch.dtype], adapters: Sequence[str], **kwargs
+) -> int:
+    """Get the number of extra bytes used to store a set of adapters per given block"""
+    with init_empty_weights(include_buffers=True):
+        block = block_config.block_class(block_config)
+        base_block_parameters = sum(p.numel() for p in block.parameters())
+        create_lora_adapter(block, quant_type=QuantType.NONE)
+
+        for adapter in adapters:
+            peft_config, peft_state_dict = load_peft(adapter, block_idx=0, **kwargs)
+            assert peft_config["peft_type"].upper() == "LORA", "only LoRA adapters are supported for now"
+            add_adapter_to_block(
+                block, block_index=0, adapter_name=adapter, peft_config=peft_config, peft_state_dict=peft_state_dict
+            )
+        adapter_parameters = sum(p.numel() for p in block.parameters()) - base_block_parameters
+    bytes_per_parameter = torch.finfo(resolve_block_dtype(block_config, torch_dtype)).bits / 8
+    return adapter_parameters * bytes_per_parameter

--- a/src/petals/utils/peft.py
+++ b/src/petals/utils/peft.py
@@ -1,6 +1,9 @@
 import re
 import time
+import os
 from typing import List, Optional, Sequence
+
+os.environ["BITSANDBYTES_NOWELCOME"] = "1"
 
 import bitsandbytes as bnb
 import peft

--- a/src/petals/utils/peft.py
+++ b/src/petals/utils/peft.py
@@ -1,6 +1,6 @@
+import os
 import re
 import time
-import os
 from typing import List, Optional, Sequence
 
 os.environ["BITSANDBYTES_NOWELCOME"] = "1"


### PR DESCRIPTION
This PR changes the way the server determines how many blocks it can handle if that server has at least one adapter. It does so by including the adapter parameters in the total block size that divides the free GPU memory.

ToDos:
- [ ] make sure adapters are actually loaded in the same dtype that was used
- [ ] update artek0chumak/bloom-560m-safe-peft to disable dropout
- [ ] create github issues from #335 comments 