### PR TITLE
If speedtest fails, assume network speed of 100 Mbit/s

### DIFF
--- a/src/petals/server/throughput.py
+++ b/src/petals/server/throughput.py
@@ -138,7 +138,7 @@ def measure_throughput_info(
 
 
 def measure_network_rps(
-    config: PretrainedConfig, *, timeout: float = 60, default_speed: float = 25e6
+    config: PretrainedConfig, *, timeout: float = 60, default_speed: float = 100e6  # 100 Mbit/s
 ) -> Optional[float]:
     bits_per_request = config.hidden_size * 16  # Clients usually send 16-bit tensors for forward/backward
     try:


### PR DESCRIPTION
The value is chosen as some safe value below average at https://health.petals.dev/

Note that if a server uses relays, the effective throughput will be further divided by 2 (see #399).