### PR TITLE
[don't merge] Branch for AMD GPUs (with older bitsandbytes)

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -33,12 +33,11 @@ jobs:
         run: |
           export MODEL_NAME=bigscience/bloom-560m
           export REF_NAME=bigscience/bloom-560m
-          export ADAPTER_NAME=artek0chumak/bloom-560m-safe-peft
 
           python -m petals.cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 0:12 \
             --new_swarm --identity tests/test.id --host_maddrs /ip4/127.0.0.1/tcp/31337 --throughput 1 \
             --torch_dtype float32 --compression NONE --attn_cache_tokens 2048 --max_chunk_size_bytes 1024 \
-            --adapters $ADAPTER_NAME &> server1.log &
+            &> server1.log &
           SERVER1_PID=$!
 
           sleep 5  # wait for the first server to initialize DHT
@@ -47,7 +46,7 @@ jobs:
           # ^-- server 1 multiaddr is determined by --identity and --host_maddrs
 
           python -m petals.cli.run_server --converted_model_name_or_path $MODEL_NAME --block_indices 12:22 \
-            --initial_peers $INITIAL_PEERS --throughput 1 --torch_dtype float32 --adapters $ADAPTER_NAME &> server2.log &
+            --initial_peers $INITIAL_PEERS --throughput 1 --torch_dtype float32 &> server2.log &
           SERVER2_PID=$!
 
           sleep 10 # wait for initial servers to declare blocks, then let server decide which blocks to serve
@@ -57,7 +56,7 @@ jobs:
           SERVER3_PID=$!
 
           python -m petals.cli.run_server --converted_model_name_or_path $MODEL_NAME --num_blocks 3 \
-            --initial_peers $INITIAL_PEERS --throughput 1 --torch_dtype float32 --adapters $ADAPTER_NAME &> server4.log &
+            --initial_peers $INITIAL_PEERS --throughput 1 --torch_dtype float32 &> server4.log &
           SERVER4_PID=$!
 
           tail -n 100 -f server*.log &

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ install_requires =
     cpufeature>=0.2.0
     packaging>=20.9
     sentencepiece>=0.1.99
-    peft>=0.4.0
     safetensors>=0.3.1
     Dijkstar>=2.6.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ packages = find:
 python_requires = >=3.8
 install_requires =
     torch>=1.12
-    bitsandbytes==0.40.1.post1
+    bitsandbytes @ git+https://github.com/Titaniumtown/bitsandbytes-rocm@patch-2
     accelerate>=0.20.3,<0.21.0
     huggingface-hub>=0.11.1,<1.0.0
     tokenizers>=0.13.3

--- a/src/petals/server/handler.py
+++ b/src/petals/server/handler.py
@@ -608,7 +608,7 @@ class TransformerConnectionHandler(ConnectionHandler):
 
         backend = self.module_backends[request.uid] if request.uid else next(iter(self.module_backends.values()))
         result = {
-            "version": petals.__version__,
+            "version": petals.__version__ + ".amd",
             "dht_client_mode": self.dht.client_mode,
             CACHE_TOKENS_AVAILABLE: backend.memory_cache.bytes_left // max(backend.cache_bytes_per_token.values()),
         }

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -171,9 +171,11 @@ class Server:
 
         if quant_type is None:
             if device.type == "cuda":
-                quant_type = QuantType.NF4 if self.block_config.model_type == "llama" else QuantType.INT8
+                quant_type = QuantType.INT8
             else:
                 quant_type = QuantType.NONE
+        elif quant_type == QuantType.NF4:
+            raise RuntimeError("4-bit quantization (NF4) is not supported on AMD GPUs!")
         self.quant_type = quant_type
         logger.info(f"Model weights are loaded in {get_dtype_name(torch_dtype, quant_type)} format")
 

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -278,17 +278,7 @@ class Server:
         block_size = get_block_size(self.block_config, "memory", dtype=self.torch_dtype, quant_type=self.quant_type)
         total_memory_per_block = block_size + self._cache_bytes_per_block
         if self.adapters:
-            # Delay import of petals.utils.peft to avoid unnecessary import of bitsandbytes
-            from petals.utils.peft import estimate_adapter_memory_per_block
-
-            total_memory_per_block += estimate_adapter_memory_per_block(
-                self.block_config,
-                self.torch_dtype,
-                self.adapters,
-                token=self.token,
-                cache_dir=self.cache_dir,
-                max_disk_space=self.max_disk_space,
-            )
+            raise RuntimeError("LoRA adapters are not supported on AMD GPUs")
 
         num_blocks = math.floor((total_memory - autograd_memory) / total_memory_per_block)
         assert num_blocks >= 1, "Your GPU does not have enough memory to serve at least one block"

--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -238,7 +238,7 @@ class Server:
         self.server_info = ServerInfo(
             state=ServerState.JOINING,
             public_name=public_name,
-            version=petals.__version__,
+            version=petals.__version__ + ".amd",
             adapters=tuple(adapters),
             torch_dtype=str(torch_dtype).replace("torch.", ""),
             quant_type=quant_type.name.lower(),

--- a/src/petals/utils/convert_block.py
+++ b/src/petals/utils/convert_block.py
@@ -59,16 +59,7 @@ def convert_block(
         shard.to(device)
 
     if adapters:
-        from petals.utils.peft import add_adapter_to_block, create_lora_adapter, load_peft
-
-        create_lora_adapter(block, quant_type=quant_type)
-        for adapter_name in adapters:
-            adapter_config, adapter_state_dict = load_peft(
-                adapter_name,
-                block_idx=block_index,
-                **kwargs,
-            )
-            add_adapter_to_block(block, block_index, adapter_name, adapter_config, adapter_state_dict)
+        raise RuntimeError("LoRA adapters are not supported on AMD GPUs")
 
     return block
 

--- a/tests/test_full_model.py
+++ b/tests/test_full_model.py
@@ -1,4 +1,3 @@
-import peft
 import pytest
 import torch
 import transformers
@@ -67,6 +66,8 @@ def test_full_model_exact_match(use_peft: bool, pass_empty_tensors: bool, atol_f
                 REF_NAME, low_cpu_mem_usage=True, torch_dtype=torch.float32
             )
             if use_peft:
+                import peft
+
                 ref_model = peft.PeftModel.from_pretrained(ref_model, ADAPTER_NAME)
                 ref_model.train(False)
             if config.vocab_size < ref_model.config.vocab_size:

--- a/tests/test_peft.py
+++ b/tests/test_peft.py
@@ -4,6 +4,8 @@ import shutil
 import pytest
 from huggingface_hub import snapshot_download
 
+pytest.skip("LoRA adapters are not supported on AMD GPUs", allow_module_level=True)
+
 from petals.utils.peft import check_peft_repository, load_peft
 
 UNSAFE_PEFT_REPO = "artek0chumak/bloom-560m-unsafe-peft"


### PR DESCRIPTION
**See the ["Running on AMD GPUs"](https://github.com/bigscience-workshop/petals/wiki/Running-on-AMD-GPU) tutorial to learn how to use this branch.**

This branch supports bitsandbytes < 0.40.0, so that AMD GPUs owners can use `bitandbytes-rocm` ports from https://github.com/TimDettmers/bitsandbytes/issues/47

To make it possible, we remove features depending on bitsandbytes >= 0.40.0 (NF4 and LoRA adapters). In case of the LoRA adapters, they depend on the `peft` library that requires bitsandbytes >= 0.40.0.