### PR TITLE
Fix typo and make blocks message more informative

### DIFF
--- a/src/petals/server/server.py
+++ b/src/petals/server/server.py
@@ -698,7 +698,7 @@ class ModuleAnnouncerThread(threading.Thread):
 
             delay = self.update_period - (time.perf_counter() - start_time)
             if delay < 0:
-                logger.warning("Declaring blocs to DHT takes more than --update_period, consider increasing it")
+                logger.warning(f"Declaring blocks to DHT takes more than --update_period, consider increasing it (currently {self.update_period})")
             self.trigger.wait(max(delay, 0))
             self.trigger.clear()
 


### PR DESCRIPTION
The message really doesn't tell me much as a user, since I never touched update_period to begin with:

```
Aug 06 09:43:07.287 [WARN] [petals.server.server.run:701] Declaring blocs to DHT takes more than --update_period, consider increasing it
```

Made it better and more informative.