### PR TITLE
Forward arbitrary kwargs

### DIFF
--- a/src/petals/server/backend.py
+++ b/src/petals/server/backend.py
@@ -5,7 +5,7 @@ from itertools import chain
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
 
 import torch
-from hivemind import BatchTensorDescriptor, TensorDescriptor
+from hivemind import BatchTensorDescriptor, TensorDescriptor, nested_flatten, nested_map
 from hivemind.moe.expert_uid import ExpertUID
 from hivemind.moe.server.module_backend import ModuleBackend
 from hivemind.utils import get_logger
@@ -96,21 +96,26 @@ class TransformerBackend(ModuleBackend):
             cache_tensors.extend((keys, values))
         return cache_tensors
 
-    def forward(self, *inputs: Union[torch.Tensor, str]) -> Tuple[torch.Tensor, ...]:
-        *inputs, active_adapter = inputs
-        with self._peft_module.using_adapter(active_adapter):
-            return super().forward(*inputs)
+    def forward(self, *args: torch.Tensor, active_adapter: Optional[str], **kwargs) -> Tuple[torch.Tensor, ...]:
+        with self._peft_module.using_adapter(active_adapter), torch.no_grad():
+            return self.module(*args, **kwargs)
 
-    def backward(self, *inputs: Union[torch.Tensor, str]) -> Tuple[torch.Tensor, ...]:
-        *inputs, active_adapter = inputs
-        with self._peft_module.using_adapter(active_adapter):
-            return super().backward(*inputs)
+    def backward(
+        self, grad_outputs: torch.Tensor, *args, active_adapter: Optional[str], **kwargs
+    ) -> Tuple[torch.Tensor, ...]:
+        assert any(x.requires_grad for x in nested_flatten((args, kwargs)) if isinstance(x, torch.Tensor))
+        with self._peft_module.using_adapter(active_adapter), torch.enable_grad():
+            (outputs,) = self.module(*args, **kwargs)
+            assert isinstance(outputs, torch.Tensor) and outputs.shape == grad_outputs.shape
+            torch.autograd.backward((outputs,), grad_tensors=(grad_outputs,), create_graph=False, retain_graph=False)
+        return nested_map(lambda x: x.grad if isinstance(x.grad, torch.Tensor) and x.requires_grad else None)
 
     @torch.inference_mode()
     def inference_step(
         self,
         hidden_states: torch.Tensor,
         hypo_ids: torch.LongTensor,
+        kwargs: Dict[str, torch.Tensor],
         inference_info: InferenceMetadata,
     ) -> Tuple[torch.Tensor, ...]:
         assert hidden_states.ndim == 3, "expected hidden states to be 3-dimensional: [batch_size, seq_len, hid_size]"
@@ -129,8 +134,9 @@ class TransformerBackend(ModuleBackend):
             layer_past = self._select_layer_past(cache_tensors, inference_info.prefix_length)
             for offset in range(0, seq_len, max_chunk_length):
                 hidden_states_chunk = hidden_states[:, offset : offset + max_chunk_length, :]
+                kwargs_chunk = self._select_kwargs_chunk(kwargs, seq_len, offset, max_chunk_length)
                 output_hidden_states_chunk, new_kvs = self.module.forward(
-                    hidden_states_chunk, layer_past=layer_past, use_cache=True
+                    hidden_states_chunk, layer_past=layer_past, use_cache=True, **kwargs_chunk
                 )
                 if seq_len > max_chunk_length:
                     output_hidden_states[:, offset : offset + max_chunk_length] = output_hidden_states_chunk
@@ -178,6 +184,17 @@ class TransformerBackend(ModuleBackend):
             new_value = new_value.view(*cache_value.shape[:2], new_length, head_dim)
             cache_value[:, :, prefix_length:new_length, :] = new_value[:, :, prefix_length:new_length, :]
 
+    @staticmethod
+    def _select_kwargs_chunk(kwargs: Dict[str, Any], seq_len: int, offset: int, max_chunk_length: int):
+        if offset == 0 and max_chunk_length >= seq_len:
+            return kwargs
+        kwargs_chunk = {}
+        for key, value in kwargs.items():
+            if isinstance(value, torch.Tensor) and value.ndim >= 2 and value.shape[-2] == seq_len:
+                value = value[:, offset : offset + max_chunk_length]
+            kwargs_chunk[key] = value
+        return kwargs_chunk
+
     def get_pools(self) -> Sequence[PrioritizedTaskPool]:
         return self.forward_pool, self.backward_pool, self.inference_pool
 
@@ -220,14 +237,17 @@ class _MergedInferenceStep:
         self,
         hidden_states: torch.Tensor,
         hypo_ids: torch.LongTensor,
+        backend_kwargs: Sequence[Dict[str, torch.Tensor]],
         inference_infos: Sequence[InferenceMetadata],
         *optional_prompts: Optional[torch.Tensor],
     ) -> Tuple[torch.Tensor, ...]:
-        assert len(inference_infos) == len(
-            optional_prompts
-        ), f"found {len(inference_infos)} blocks but {len(optional_prompts)} prompts"
-        for inference_info, optional_prompt in zip(inference_infos, optional_prompts):
+        assert (
+            len(inference_infos) == len(optional_prompts) == len(backend_kwargs)
+        ), f"mismatch: got {len(inference_infos)} infos, {len(optional_prompts)} prompts, {len(backend_kwargs)} kwargs"
+        for inference_info, optional_prompt, kwargs in zip(inference_infos, optional_prompts, backend_kwargs):
             if optional_prompt is not None:
                 hidden_states[:, : optional_prompt.shape[1]] += optional_prompt
-            (hidden_states,) = self.backends[inference_info.uid].inference_step(hidden_states, hypo_ids, inference_info)
+            (hidden_states,) = self.backends[inference_info.uid].inference_step(
+                hidden_states, hypo_ids, kwargs, inference_info
+            )
         return (hidden_states,)

--- a/src/petals/server/handler.py
+++ b/src/petals/server/handler.py
@@ -180,7 +180,7 @@ class TransformerConnectionHandler(ConnectionHandler):
                         prioritizer=self._prioritizer,
                         points=points,
                         quant_type=self.quant_type,
-                        args_structure=args_structure,
+                        structure=args_structure,
                     ):
                         if can_push:
                             task = asyncio.create_task(self._push_outputs(request, output_tensors[0], metadata))
@@ -368,7 +368,7 @@ class TransformerConnectionHandler(ConnectionHandler):
                 prioritizer=self._prioritizer,
                 active_adapter=active_adapter,
                 points=points,
-                args_structure=args_structure,
+                structure=args_structure,
             )
             return runtime_pb2.ExpertResponse(
                 tensors=self._serialize_outputs(hidden_states, requested_backends, metadata)
@@ -397,7 +397,7 @@ class TransformerConnectionHandler(ConnectionHandler):
                 prioritizer=self._prioritizer,
                 active_adapter=active_adapter,
                 points=points,
-                args_structure=args_structure,
+                structure=args_structure,
             )
 
             # Split the serialized_output for streaming and respond to client
@@ -450,7 +450,7 @@ class TransformerConnectionHandler(ConnectionHandler):
                 prioritizer=self._prioritizer,
                 active_adapter=active_adapter,
                 points=points,
-                args_structure=args_structure,
+                structure=args_structure,
             )
 
             return runtime_pb2.ExpertResponse(tensors=self._serialize_grads(grads, requested_backends, metadata))
@@ -477,7 +477,7 @@ class TransformerConnectionHandler(ConnectionHandler):
                 prioritizer=self._prioritizer,
                 active_adapter=active_adapter,
                 points=points,
-                args_structure=args_structure,
+                structure=args_structure,
             )
             # Split the serialized_grad_inputs for streaming and respond
             for tensor in self._serialize_grads(grads, requested_backends, metadata):

--- a/src/petals/utils/packaging.py
+++ b/src/petals/utils/packaging.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any, Tuple, Sequence
 
 import torch
 from hivemind import nested_flatten, nested_pack
@@ -18,7 +18,7 @@ def _get_tensor_index(item: bytes) -> int:
     return int(item[3:])
 
 
-def pack_args_kwargs(*args, **kwargs) -> Tuple[List[torch.Tensor], Any]:
+def pack_args_kwargs(*args, **kwargs) -> Tuple[Sequence[torch.Tensor], Any]:
     """
     Check the function's arguments and pack all tensors into different flattened lists.
     :returns: a flattened list of tensors and args and kwargs, where tensors were masked
@@ -35,7 +35,7 @@ def pack_args_kwargs(*args, **kwargs) -> Tuple[List[torch.Tensor], Any]:
     return flat_tensors, nested_pack(masked_flat_values, (args, kwargs))
 
 
-def unpack_args_kwargs(flat_tensors: List[torch.Tensor], args_structure: Any):
+def unpack_args_kwargs(flat_tensors: Sequence[torch.Tensor], args_structure: Any):
     """
     Restore arguments after `pack_args_kwargs` function.
     :returns: list of args and dict of kwargs


### PR DESCRIPTION
NB: this pull request makes several drastic changes to the backend, block_functions and pools. If it interferes with long-term plans for the codebase, please raise a concern - i'm happy to rollback any detrimetnal changes.

Feature
- [x] servers will now support arbitrary kwargs for transformers blocks
- [ ] servers can now backprop w.r.t. additional keyword args and return gradients

Internal codebase changes:
- [ ] TransformerBackend no longer inherits hivemind ModuleBackend
    - ... and therefore does not trigger (empty) optimizer & scheduler, saving/loading the (unused) training state, etc
    -  as of right now, 50% ModuleBackend methods are rewritten in TransformerBackend and the other 50% are unused

- [x] Task and PrioritizedTaskPool support kwargs
    - note: if we (eventually) implement server-side batching, we can only batch queries if they have the same input schema anyway
        , and therefore, this pull request does not make server-side batching any more complicated than it already is


Tests:
- [ ] everything that used to work works again
- [ ] forward with extra kwargs
- [ ] inference with attention mask **chunking**
- [ ] full model exact match with attention mask
- [ ] block-level backward with non-differentiable kwargs
- [ ] block-level backward with differentiable kwargs