### PR TITLE
Temporarily require peft<0.5.0, transformers<4.32.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     accelerate>=0.20.3,<0.21.0
     huggingface-hub>=0.11.1,<1.0.0
     tokenizers>=0.13.3
-    transformers>=4.31.0,<5.0.0
+    transformers>=4.31.0,<4.32.0
     speedtest-cli==2.1.3
     pydantic>=1.10,<2.0  # 2.0 is incompatible with hivemind yet
     hivemind==1.1.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     cpufeature>=0.2.0
     packaging>=20.9
     sentencepiece>=0.1.99
-    peft>=0.4.0
+    peft==0.4.0
     safetensors>=0.3.1
     Dijkstar>=2.6.0
 


### PR DESCRIPTION
Peft 0.5 recently released and broke some compatilibities. This PR temporarily requires petals to use the previous stable version of peft while we work on 0.5.0 support.

note to @borzunov : there are no intermediate versions between 0.4.0 and 0.5.0