### PR TITLE
Support transformers 4.32.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     accelerate>=0.20.3,<0.21.0
     huggingface-hub>=0.11.1,<1.0.0
     tokenizers>=0.13.3
-    transformers>=4.31.0,<4.32.0
+    transformers>=4.31.0,<5.0.0
     speedtest-cli==2.1.3
     pydantic>=1.10,<2.0  # 2.0 is incompatible with hivemind yet
     hivemind==1.1.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     accelerate>=0.20.3,<0.21.0
     huggingface-hub>=0.11.1,<1.0.0
     tokenizers>=0.13.3
-    transformers>=4.31.0,<4.32.0
+    transformers>=4.32.0
     speedtest-cli==2.1.3
     pydantic>=1.10,<2.0  # 2.0 is incompatible with hivemind yet
     hivemind==1.1.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     accelerate>=0.20.3,<0.21.0
     huggingface-hub>=0.11.1,<1.0.0
     tokenizers>=0.13.3
-    transformers>=4.31.0,<5.0.0
+    transformers>=4.31.0,<4.32.0
     speedtest-cli==2.1.3
     pydantic>=1.10,<2.0  # 2.0 is incompatible with hivemind yet
     hivemind==1.1.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ install_requires =
     cpufeature>=0.2.0
     packaging>=20.9
     sentencepiece>=0.1.99
-    peft>=0.4.0
+    peft==0.4.0
     safetensors>=0.3.1
     Dijkstar>=2.6.0
 

--- a/src/petals/server/from_pretrained.py
+++ b/src/petals/server/from_pretrained.py
@@ -61,7 +61,7 @@ def load_pretrained_block(
     )
 
     # dummy load, check that keys match
-    report = block.load_state_dict(state_dict, strict=True)
+    report = block.load_state_dict(state_dict, strict=False)
     assert not report.missing_keys, f"Some block weights are missing: {report.missing_keys}"
 
     for param_name, _ in block.named_parameters():


### PR DESCRIPTION
The new transformer release removed inv_freq buffer from all llama models.
To support this, we need to allow unused tensors in pretrained llama blocks until hub maintainers update their models (which will take a while)

![image](https://github.com/bigscience-workshop/petals/assets/3491902/0cfb5566-302e-41dd-8676-d802c6149e20)


Full release notes
https://github.com/huggingface/transformers/releases/tag/v4.32.0