### PR TITLE
Don't install cpufeature on non-x86_64 machines

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ install_requires =
     tensor_parallel==1.0.23
     humanfriendly
     async-timeout>=4.0.2
-    cpufeature>=0.2.0
+    cpufeature>=0.2.0; platform_machine == "x86_64"
     packaging>=20.9
     sentencepiece>=0.1.99
     peft>=0.5.0


### PR DESCRIPTION
Necessary since cpufeature crashes when installing on ARM.