### PR TITLE
Create model index in DHT

### DIFF
--- a/src/petals/client/inference_session.py
+++ b/src/petals/client/inference_session.py
@@ -343,7 +343,7 @@ class InferenceSession:
         n_prev_spans = len(self._server_sessions)
         update_end = self._server_sessions[server_idx].span.end if server_idx < n_prev_spans else self.num_blocks
         if attempt_no >= 1:
-            logger.info(
+            logger.debug(
                 f"Due to a server failure, remote attention caches "
                 f"from block {block_idx} to {update_end} will be regenerated"
             )

--- a/src/petals/data_structures.py
+++ b/src/petals/data_structures.py
@@ -21,6 +21,19 @@ RPS = pydantic.confloat(ge=0, allow_inf_nan=False, strict=True)
 
 
 @pydantic.dataclasses.dataclass
+class ModelInfo:
+    num_blocks: int
+    repository: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_dict(cls, source: dict):
+        return cls(**source)
+
+
+@pydantic.dataclasses.dataclass
 class ServerInfo:
     state: ServerState
     throughput: RPS


### PR DESCRIPTION
This PR creates an index of models hosted in the swarm - it is useful to know which custom models users run and display them at https://health.petals.dev as "not officially supported" models.

After this PR:

```python
In [1]: import hivemind 

In [2]: from petals.constants import PUBLIC_INITIAL_PEERS                                                                  
                                                                                                    
In [3]: dht = hivemind.DHT(initial_peers=PUBLIC_INITIAL_PEERS, client_mode=True, start=True)
                                                                    
In [4]: dht.get("_petals.models")                                                                  
Out[4]: ValueWithExpiration(value={'llama-65b-hf': ValueWithExpiration(value={'num_blocks': 80, 'repository': 'https://huggingface.co/huggyllama/llama-65b'}, expiration_time=1693462442.2670343)}, expiration
_time=1693462442.2670343)        
```