### PR TITLE
Add position_ids argument to DistributedFalconModel

### DIFF
--- a/src/petals/models/falcon/model.py
+++ b/src/petals/models/falcon/model.py
@@ -47,6 +47,7 @@ class DistributedFalconModel(DefaultRevisionMixin, FromPretrainedMixin, PTuneMix
         input_ids: Optional[torch.LongTensor] = None,
         past_key_values: Optional[RemotePastKeyValues] = None,
         attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
         head_mask: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.LongTensor] = None,
         use_cache: Optional[bool] = None,
@@ -68,6 +69,9 @@ class DistributedFalconModel(DefaultRevisionMixin, FromPretrainedMixin, PTuneMix
         assert (
             attention_mask is None or (attention_mask == 1).all()
         ), f"Custom attention masks are not supported, {attention_mask=}"
+        assert (
+            position_ids is None or (position_ids[:, 1:] - position_ids[:, :-1] == 1).all()
+        ), f"Non-consecutive position_ids are not supported, {position_ids=}"
         assert head_mask is None, f"Custom head masks are not supported, {head_mask=}"
         assert use_cache is None or use_cache, f"{use_cache=} is not supported"
         assert not output_attentions, f"{output_attentions=} is not supported"


### PR DESCRIPTION
In https://github.com/huggingface/transformers/commit/a796f7eea6c86b54671a6f522cebbe41f630bb62, Falcon started supporting the position_ids argument and passing it to the model. The current code for `DistributedFalconModel.forward` does not handle this argument, which results in [errors](https://github.com/bigscience-workshop/petals/actions/runs/6269322273/job/17505647840#step:7:1102) when running tests. This PR fixes the problem by handling `position_ids` similarly to the LLaMA model.