### PR TITLE
Hotfix: require peft version 0.5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     cpufeature>=0.2.0; platform_machine == "x86_64"
     packaging>=20.9
     sentencepiece>=0.1.99
-    peft>=0.5.0
+    peft==0.5.0
     safetensors>=0.3.1
     Dijkstar>=2.6.0
 


### PR DESCRIPTION
This is a workaround that rollbacks peft update to circumvent the following error:
![image](https://github.com/bigscience-workshop/petals/assets/3491902/df0a1776-1c50-428a-8089-a36259cf7166)

https://github.com/bigscience-workshop/petals/actions/runs/6786565951/job/18447373891