### PR TITLE
Clean disk space in push-docker-image.yaml

### DIFF
--- a/.github/workflows/push-docker-image.yaml
+++ b/.github/workflows/push-docker-image.yaml
@@ -42,6 +42,17 @@ jobs:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
+      - name: Free disk space on Ubuntu runner
+        uses: kfir4444/free-disk-space@main
+        with:
+          # found in: https://github.com/docker/build-push-action/issues/968
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2


### PR DESCRIPTION
Docker build currently fails on main: https://github.com/bigscience-workshop/petals/actions/runs/7915836557/job/21608494128


This PR attempts to clean disk space in docker using a disk cleaner action found in https://github.com/docker/build-push-action/issues/968