### PR TITLE
Restrict PyTorch version to <2.3.0 to resolve import error

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    torch==2.2.2
+    torch>=1.12,<2.3.0
     bitsandbytes==0.41.1
     accelerate>=0.27.2
     huggingface-hub>=0.11.1,<1.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ package_dir =
 packages = find:
 python_requires = >=3.8
 install_requires =
-    torch>=1.12
+    torch==2.2.2
     bitsandbytes==0.41.1
     accelerate>=0.27.2
     huggingface-hub>=0.11.1,<1.0.0


### PR DESCRIPTION
Fixes #576
This addresses the import error encountered with PyTorch 2.3.0 as detailed in issue #576. The error 'cannot import name '_refresh_per_optimizer_state' from 'torch.cuda.amp.grad_scaler' is resolved by pinning the PyTorch version to 2.2.2 in setup.cfg.

Small change:
- Updated `setup.cfg` to specify `torch==2.2.2` under `install_requires`.