### PR TITLE
Update hivemind to support torch >= 2.3.0, pydantic >= 2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     transformers==4.43.1  # if you change this, please also change version assert in petals/__init__.py
     speedtest-cli==2.1.3
     pydantic>=1.10,<2.0  # 2.0 is incompatible with hivemind yet
-    hivemind==1.1.10.post2
+    hivemind @ git+https://github.com/learning-at-home/hivemind.git@f98acba7aa3cf93717c40ca95d0b4e5b5742414c
     tensor_parallel==1.0.23
     humanfriendly
     async-timeout>=4.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     tokenizers>=0.13.3
     transformers==4.43.1  # if you change this, please also change version assert in petals/__init__.py
     speedtest-cli==2.1.3
-    pydantic>=1.10,<2.0  # 2.0 is incompatible with hivemind yet
     hivemind @ git+https://github.com/learning-at-home/hivemind.git@f98acba7aa3cf93717c40ca95d0b4e5b5742414c
     tensor_parallel==1.0.23
     humanfriendly


### PR DESCRIPTION
Updates hivemind to https://github.com/learning-at-home/hivemind/commit/f98acba7aa3cf93717c40ca95d0b4e5b5742414c that supports torch >= 2.3.0, pydantic >= 2.0.